### PR TITLE
Delete storage format

### DIFF
--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -537,8 +537,8 @@
 					<xs:element name="NumeratorCoefficient" minOccurs="0" maxOccurs="unbounded">
 						<xs:complexType>
 							<xs:simpleContent>
-								<xs:extension base="xs:double">
-									<xs:attribute name="i" type="xs:integer"/>
+								<xs:extension base="fsx:FloatNoUnitType">
+									<xs:attribute name="number" type="fsx:CounterType"/>
 								</xs:extension>
 							</xs:simpleContent>
 						</xs:complexType>
@@ -565,10 +565,24 @@
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:element>
-					<xs:element name="Numerator" type="fsx:FloatType" minOccurs="0"
-						maxOccurs="unbounded"/>
-					<xs:element name="Denominator" type="fsx:FloatType" minOccurs="0"
-						maxOccurs="unbounded"/>
+					<xs:element name="Numerator" minOccurs="0" maxOccurs="unbounded">
+						<xs:complexType>
+							<xs:simpleContent>
+								<xs:extension base="fsx:FloatNoUnitType">
+									<xs:attribute name="number" type="fsx:CounterType"/>
+								</xs:extension>
+							</xs:simpleContent>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="Denominator" minOccurs="0" maxOccurs="unbounded">
+						<xs:complexType>
+							<xs:simpleContent>
+								<xs:extension base="fsx:FloatNoUnitType">
+									<xs:attribute name="number" type="fsx:CounterType"/>
+								</xs:extension>
+							</xs:simpleContent>
+						</xs:complexType>
+					</xs:element>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>

--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -297,12 +297,6 @@
 						</xs:simpleType>
 					</xs:element>
 					<xs:group ref="fsx:SampleRateGroup" minOccurs="0"/>
-					<xs:element name="StorageFormat" type="xs:string" minOccurs="0">
-						<xs:annotation>
-							<xs:documentation>The storage format of the recorded data (e.g.
-								SEED).</xs:documentation>
-						</xs:annotation>
-					</xs:element>
 					<xs:element name="ClockDrift" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>A tolerance value, measured in seconds per sample,

--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -531,8 +531,8 @@
 					<xs:element name="NumeratorCoefficient" minOccurs="0" maxOccurs="unbounded">
 						<xs:complexType>
 							<xs:simpleContent>
-								<xs:extension base="fsx:FloatNoUnitType">
-									<xs:attribute name="number" type="fsx:CounterType"/>
+								<xs:extension base="xs:double">
+									<xs:attribute name="i" type="xs:integer"/>
 								</xs:extension>
 							</xs:simpleContent>
 						</xs:complexType>
@@ -559,24 +559,10 @@
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:element>
-					<xs:element name="Numerator" minOccurs="0" maxOccurs="unbounded">
-						<xs:complexType>
-							<xs:simpleContent>
-								<xs:extension base="fsx:FloatNoUnitType">
-									<xs:attribute name="number" type="fsx:CounterType"/>
-								</xs:extension>
-							</xs:simpleContent>
-						</xs:complexType>
-					</xs:element>
-					<xs:element name="Denominator" minOccurs="0" maxOccurs="unbounded">
-						<xs:complexType>
-							<xs:simpleContent>
-								<xs:extension base="fsx:FloatNoUnitType">
-									<xs:attribute name="number" type="fsx:CounterType"/>
-								</xs:extension>
-							</xs:simpleContent>
-						</xs:complexType>
-					</xs:element>
+					<xs:element name="Numerator" type="fsx:FloatType" minOccurs="0"
+						maxOccurs="unbounded"/>
+					<xs:element name="Denominator" type="fsx:FloatType" minOccurs="0"
+						maxOccurs="unbounded"/>
 				</xs:sequence>
 			</xs:extension>
 		</xs:complexContent>


### PR DESCRIPTION
Storage format seems to be a property of the waveforms themselves and is not really appropriate for metadata. In many cases the same waveform data will be available in several storage formats, but all will need the same stationXML metadata.
