### PR TITLE
Limit each <Operator> to a single <Agency>

### DIFF
--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -156,7 +156,7 @@
 								formation.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Equipment" type="fsx:EquipmentType" minOccutorrs="0"
+					<xs:element name="Equipment" type="fsx:EquipmentType" minOccurs="0"
 						maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>Equipment used by all channels at a
@@ -165,7 +165,12 @@
 					</xs:element>
 					<xs:element name="Operator" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
-							<xs:documentation>An operating agency and associated contact persons. If there multiple operators, each one should be encapsulated within an Operator tag. Since the Contact element is a generic type that represents any contact person, it also has its own optional Agency element. It is expected that typically the contact’s optional Agency tag will match the Operator Agency. Only contacts appropriate for the enclosing Station should be include in the Operator tag.</xs:documentation>
+							<xs:documentation>An operating agency and associated contact persons. 
+								If there multiple operators, each one should be encapsulated within an Operator tag. 
+								Since the Contact element is a generic type that represents any contact person, 
+								it also has its own optional Agency element. It is expected that typically the 
+								contact’s optional Agency tag will match the Operator Agency. 
+								Only contacts appropriate for the enclosing Station should be include in the Operator tag.</xs:documentation>
 						</xs:annotation>
 						<xs:complexType>
 							<xs:sequence>

--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -166,14 +166,14 @@
 					<xs:element name="Operator" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>An operating agency and associated contact persons. If
-								there multiple operators, each one should be encapsulated within an
+								there multiple agencies acting as operators, each one should be encapsulated within an
 								Operator tag. Since the Contact element is a generic type that
 								represents any contact person, it also has its own optional Agency
 								element.</xs:documentation>
 						</xs:annotation>
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="Agency" type="xs:string" maxOccurs="unbounded"/>
+								<xs:element name="Agency" type="xs:string"/>
 								<xs:element name="Contact" type="fsx:PersonType" minOccurs="0"
 									maxOccurs="unbounded"/>
 								<xs:element name="WebSite" type="xs:anyURI" minOccurs="0"/>

--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -156,7 +156,7 @@
 								formation.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Equipment" type="fsx:EquipmentType" minOccurs="0"
+					<xs:element name="Equipment" type="fsx:EquipmentType" minOccutorrs="0"
 						maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>Equipment used by all channels at a
@@ -165,11 +165,7 @@
 					</xs:element>
 					<xs:element name="Operator" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
-							<xs:documentation>An operating agency and associated contact persons. If
-								there multiple agencies acting as operators, each one should be encapsulated within an
-								Operator tag. Since the Contact element is a generic type that
-								represents any contact person, it also has its own optional Agency
-								element.</xs:documentation>
+							<xs:documentation>An operating agency and associated contact persons. If there multiple operators, each one should be encapsulated within an Operator tag. Since the Contact element is a generic type that represents any contact person, it also has its own optional Agency element. It is expected that typically the contact’s optional Agency tag will match the Operator Agency. Only contacts appropriate for the enclosing Station should be include in the Operator tag.</xs:documentation>
 						</xs:annotation>
 						<xs:complexType>
 							<xs:sequence>

--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -165,11 +165,12 @@
 					</xs:element>
 					<xs:element name="Operator" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
-							<xs:documentation>An operating agency and associated contact persons. 
-								If there multiple operators, each one should be encapsulated within an Operator tag. 
-								Since the Contact element is a generic type that represents any contact person, 
-								it also has its own optional Agency element. It is expected that typically the 
-								contact’s optional Agency tag will match the Operator Agency. 
+							<xs:documentation>An operating agency and associated contact persons. If
+								there multiple operators, each one should be encapsulated within an
+								Operator tag. Since the Contact element is a generic type that
+								represents any contact person, it also has its own optional Agency
+								element.
+								It is expected that typically the contact’s optional Agency tag will match the Operator Agency. 
 								Only contacts appropriate for the enclosing Station should be include in the Operator tag.</xs:documentation>
 						</xs:annotation>
 						<xs:complexType>


### PR DESCRIPTION
(Also posted to WG list)

Here are some use cases that prompt this proposal:

Case 1) Multiple Stations per Agency: It is certainly not uncommon for an agency to function as an operator for more than one station. It is possible that the contacts from that agency vary from station to station. It seems ideal to have the `<Operator>` only contain those `<Contact>`s that are relevant to the enclosing station, and not list all `<Contact>`s associated with the agency involved. While the schema doesn’t enforce which `<Contact>`s are included, I suggest the intention be made clear that only those <Contact> related to the enclosing `<Station>` be included in the station `<Operator>` element.

Case 2) Multiple Agency per Station: If two distinct Agencies, with distinct contacts, are operators for a single Station, the schema suggests that they should each be in their own `<Operator>` tag. Allowing multiple Agencies within a single `<Operator>` seems to contradict this. In addition, since the enclosed `<Agency>` and `<Contact>` tags are siblings, the children of `<Operator>` could end up being an unstructured collection of multiple `<Agency>`s and multiple `<Contact>`s (from multiple agencies). It get

The proposed change would have the following benefits:

1) Reinforce the intention that each distinct operator should be encapsulated in its own `<Operator>` element. Allowing more than one `<Agency>` seems counter to this intention.

2) The `<Contact>`s included within `<Operator>` would then be those contacts associated with (single) sibling `<Agency>` element, as appropriate for the enclosing `<Station>`. While there is no schema requirement that the `<Agency>` within `<Contact>` match the `<Agency>` within `<Operator>`, I would suggest that this be the preferred/expected behavior. (Making a requirement that the `<Operator>` and `<Contact>` `<Agency>` tags match would involve more substantial schema changes). Overall, this results in an `<Operator>` element with children that are all related in an intuitive way.

3) By adopting this change, the internal structure of the `<Operator>` element is in line with the natural relationship between `<Agency>` and `<Contact>` metadata, facilitating the generation of StationXML from a database managing the station metadata.

I am proposing this simple change to `<Operator>` in the interest of minimizing change to the schema. However, there are certainly other, more involved, approaches that would get to the same conceptual place. For example, a new complex type of AgencyType could be constructed that would encapsulate the Agency info (name, URL, etc), and zero or more `<Contacts>`. Then `<Operator>` could be redefined as zero or more `<Agency>`s. If this is preferred, I can make those changes and submit as a git pull request instead of the simpler solution I am proposing currently.
