### PR TITLE
add Operator to NetworkType

### DIFF
--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -119,6 +119,23 @@
 								the Network level.) </xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="Operator" minOccurs="0" maxOccurs="unbounded">
+						<xs:annotation>
+							<xs:documentation>An operating agency and associated contact persons. If
+								there multiple operators, each one should be encapsulated within an
+								Operator tag. Since the Contact element is a generic type that
+								represents any contact person, it also has its own optional Agency
+								element.</xs:documentation>
+						</xs:annotation>
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Agency" type="xs:string" maxOccurs="unbounded"/>
+								<xs:element name="Contact" type="fsx:PersonType" minOccurs="0"
+									maxOccurs="unbounded"/>
+								<xs:element name="WebSite" type="xs:anyURI" minOccurs="0"/>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
 					<xs:element name="Station" type="fsx:StationType" minOccurs="0"
 						maxOccurs="unbounded"/>
 				</xs:sequence>


### PR DESCRIPTION
In most cases, all stations for a network will have a single Operator, but currently Operator only exists at the Station level. Adding Operator to the NetworkType would allow putting the contact information in one place instead of repeating for each station, and allows this information to be discovered without including stations, for example when getting StationXML from the FDSN Station web service with level=network.

This should be modified to be compatible with pull request #9 to have single Agency per Operator, which is probably easier if Operator is refactored into OperatorType for reuse, but I have not done that to keep this pull request self contained.
