### PR TITLE
Include StationXML 1.0 to 1.1 XSLT transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,11 @@ related in order to streamline review and acceptance.
 
 ## Translating StationXML 1.0 to 1.1
 
+The vast majority of the StationXML 1.0 schema exists in the 1.1 schema, making most 1.0 documents compatible
+with the 1.1 schema.  There are a few small exceptions where 1.0 elements were removed from 1.1, in one
+important case to avoid the specification of incorrect metadata.
+
 An [XSLT definition for StationXML 1.0 to 1.1 conversion](StationXML-1.0to1.1.xslt) exists to assist
-with the conversion of version 1.0 documents to the version 1.1 schema.
+with the systematic conversion of version 1.0 documents to the version 1.1 schema.  This is done by removing the
+elements no longer allowed in 1.1.
+

--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ described above, must be followed for any changes to the schema.
 
 Changes and issues should only be grouped together when logically
 related in order to streamline review and acceptance.
+
+## Translating StationXML 1.0 to 1.1
+
+An [XSLT definition for StationXML 1.0 to 1.1 conversion](StationXML-1.0to1.1.xslt) exists to assist
+with the conversion of version 1.0 documents to the version 1.1 schema.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ described above, must be followed for any changes to the schema.
 Changes and issues should only be grouped together when logically
 related in order to streamline review and acceptance.
 
-## Translating StationXML 1.0 to 1.1
+## Translating StationXML 1.0 to 1.1 and later releases
 
 The vast majority of the StationXML 1.0 schema exists in the 1.1 schema, making most 1.0 documents compatible
 with the 1.1 schema.  There are a few small exceptions where 1.0 elements were removed from 1.1, in one

--- a/StationXML-1.0to1.1.xslt
+++ b/StationXML-1.0to1.1.xslt
@@ -1,0 +1,39 @@
+<xsl:transform version="1.0"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+ xmlns:fsx="http://www.fdsn.org/xml/station/1">
+
+    <!--
+    This XSLT 1.0 transform may be used to translate a StationXML version 1.0 document to version 1.1
+    Version: 2020-04-07
+
+    The document *must* declare the FDSN StationXML elements in a namespace of "http://www.fdsn.org/xml/station/1"
+
+    The following changes are applied by the transformation:
+    1) Change FDSNStationXML@schemaVersion from 1.0 to 1.1
+    2) Remove any .../Channel/StorageFormat elements, which are not allowed in 1.1
+    3) Remove any .../Channel/Response/Stage/StageGain elements when
+                  .../Channel/Response/Stage/Polynomial elements are present,
+         which are not allowed in 1.1 as they are nearly always incompatible.
+         Note: This tranformation assumes the StageGain elements are in the document by
+         error (to stricly conform to 1.0) and the Polynomial is the intended filter.
+    -->
+
+    <!-- Identity template: copy all input to output and apply the included templates -->
+    <xsl:template match="node() | @*">
+      <xsl:copy>
+         <xsl:apply-templates select="node() | @*"/>
+      </xsl:copy>
+    </xsl:template>
+
+    <!-- Change schemaVersion from 1.0 to 1.1 -->
+    <xsl:template match="/fsx:FDSNStationXML/@schemaVersion[. = '1.0']">
+      <xsl:attribute name="schemaVersion">1.1</xsl:attribute>
+    </xsl:template>
+
+    <!-- Remove StorageFormat -->
+    <xsl:template match="/fsx:FDSNStationXML/fsx:Network/fsx:Station/fsx:Channel/fsx:StorageFormat"/>
+
+    <!-- Remove StageGain element from Stage that contains Polynomial -->
+    <xsl:template match="/fsx:FDSNStationXML/fsx:Network/fsx:Station/fsx:Channel/fsx:Response/fsx:Stage[fsx:Polynomial]/fsx:StageGain"/>
+
+</xsl:transform>


### PR DESCRIPTION
This PR adds an XSLT transformation to convert StationXML 1.0 documents to schema version 1.1.

Background: the changes in StationXML version 1.0 to 1.1 were mostly backwards compatible.  The known exceptions are as follows:
* The `<StorageFormat>` child of `<Channel>` is no longer allowed in 1.1
* A `<StageGain>` child of `<Response>` is no longer _required_ and now disallowed when a `<Polynomial>` is present.   Note: this flaw in the 1.0 schema required authors to create internally inconsistent responses, as the use of `<Polynomial>` is almost always incompatible with a `<StageGain>`.

The included XSLT transformation transforms a 1.0 document to 1.1 by removing these unallowed  elements, while changing the `schemaVersion` attribute from `1.0` to `1.1`.
