### PR TITLE
Lax example

### DIFF
--- a/docs/convert_xsd_to_rst.py
+++ b/docs/convert_xsd_to_rst.py
@@ -87,7 +87,6 @@ def write_tree(element, outfile, first_time = True):
     descriptions = []
 
     stored_description_default=False
-    stored_example_default=False
 
     if element.annotation:
         for note in element.annotation:
@@ -99,34 +98,14 @@ def write_tree(element, outfile, first_time = True):
                 else:
                     isDefault=False
 
-                example_location=note.find("Example:")
-                if example_location != -1:
-                    if not isDefault:
-                         if stored_example_default:
-                             examples.clear()
-                         examples.append(note[example_location+8:])
+                if not isDefault:
+                     if stored_description_default:
+                         descriptions.clear()
+                     descriptions.append(note)
 
-
-                    elif isDefault and len(examples)==0:
-                        examples.append(note[example_location+8:])
-                        stored_example_default=True
-
-                if example_location!=0:
-                    #If we have one that isn't default, and there are ones that are default, replace.
-                    #If we have one that isn't default, and there aren't, just add.
-                    if example_location!=-1:
-                        toAdd=note[:example_location]
-                    else:
-                        toAdd=note
-
-                    if not isDefault:
-                         if stored_description_default:
-                             descriptions.clear()
-                         descriptions.append(toAdd)
-
-                    elif isDefault and len(descriptions)==0:
-                        descriptions.append(toAdd)
-                        stored_description_default=True
+                elif isDefault and len(descriptions)==0:
+                    descriptions.append(note)
+                    stored_description_default=True
 
                 if note.find("Warning:") == 0:
                     warnings.append(note[8:])
@@ -243,25 +222,11 @@ def write_tree(element, outfile, first_time = True):
                         #print(note+" "+old_note, file=sys.stderr)
                         isDefault=False
 
-                    example_location=note.find("Example:")
-                    if example_location != -1:
-                        if not isDefault:
-                             example = note[example_location+8:]
+                    if not isDefault:
+                         description = note
 
-                        elif isDefault and len(example)==0:
-                            example = note[example_location+8:]
-
-                    if example_location != 0:
-                        if example_location!=-1:
-                            toAdd= note[:example_location]
-                        else:
-                            toAdd= note
-
-                        if not isDefault:
-                             description = toAdd
-
-                        elif isDefault and len(description)==0:
-                            description = toAdd
+                    elif isDefault and len(description)==0:
+                        description = note
 
             print("      **%s**, :ref:`%s<type-glossary>`, %s, \"%s\", \"%s\" " % (attrib.name, attrib.type,required, description, example), file=outfile)
 

--- a/docs/convert_xsd_to_rst.py
+++ b/docs/convert_xsd_to_rst.py
@@ -229,7 +229,9 @@ def write_tree(element, outfile, first_time = True):
 
             description = ""
             example = ""
-
+            if len(attrib.example) != 0:
+                DQ='"'
+                example = f"{attrib.name}=\{DQ}{attrib.example[0].text}\{DQ}"
             for note in attrib.annotation:
                 old_note=note[:]
                 note=isRightChoice(note,element)
@@ -369,6 +371,7 @@ class Attribute(object):
         self.local_name = local_name
         self.required = required
         self.annotation = []
+        self.example = []
         self.type = type
 
         if annotation is not None:
@@ -377,6 +380,9 @@ class Attribute(object):
 
     def add_annotation(self, note):
         self.annotation.append(note)
+
+    def add_example(self, ex):
+        self.example.append(ex)
 
     def __repr__(self):
 
@@ -546,9 +552,12 @@ def walk_tree(xsd_element, stop_element, level=1, last_elem=None, context=None):
 
         if attrib.annotation is not None:
             for y in attrib.annotation.documentation:
-                text = " ".join(y.text.split())
-                attr.add_annotation(text)
-                #print("%s MTH: Add attrib annotation:[%s]" % (space, text), file=sys.stderr)
+                for ex in y.findall("example"):
+                    attr.add_example(ex)
+                if y.text is not None:
+                    text = " ".join(y.text.split())
+                    attr.add_annotation(text)
+                    #print("%s MTH: Add attrib annotation:[%s]" % (space, text), file=sys.stderr)
 
     # xsd_element.type is always some form of XsdComplexType
     # xsd_element.type.content_type is either XsdGroup, XsdAtomicBuiltin or XsdAtomicRestriction
@@ -575,7 +584,6 @@ def walk_tree(xsd_element, stop_element, level=1, last_elem=None, context=None):
                     if e.annotation is not None:
                         for y in e.annotation.documentation:
                             for ex in y.findall("example"):
-                                print(f"590 found example: {ex[0].tag}")
                                 subElement.add_example(ex)
                             if y.text != None:
                                 text = " ".join(y.text.split())

--- a/docs/convert_xsd_to_rst.py
+++ b/docs/convert_xsd_to_rst.py
@@ -82,8 +82,6 @@ def write_tree(element, outfile, first_time = True):
         print("      %s\n" % crumb, file=outfile)
         #print("      crumb:%s\n" % crumb, file=outfile)
 
-    examples = []
-    warnings = []
     descriptions = []
 
     stored_description_default=False
@@ -109,11 +107,10 @@ def write_tree(element, outfile, first_time = True):
 
                 if note.find("Warning:") == 0:
                     warnings.append(note[8:])
-    for example in element.example:
-        examples.append(example)
-    for warning in warnings:
+
+    for warning in element.warning:
         print("   .. admonition:: Warning\n", file=outfile)
-        print("      %s\n" % warning, file=outfile)
+        print("      %s\n" % warning.text, file=outfile)
 
     if element.type:
         print("   .. container:: type\n", file=outfile)
@@ -163,7 +160,7 @@ def write_tree(element, outfile, first_time = True):
             print("      %s.\n" % description, file=outfile)
 
     # Add period if needs it
-    for example in examples:
+    for example in element.example:
         exampleStr = ""
         if isinstance(example, ElementTree.Element):
             if example.get('LevelChoice') is not None and element.parent is not None:
@@ -337,6 +334,7 @@ class Attribute(object):
         self.required = required
         self.annotation = []
         self.example = []
+        self.warning = []
         self.type = type
 
         if annotation is not None:
@@ -348,6 +346,9 @@ class Attribute(object):
 
     def add_example(self, ex):
         self.example.append(ex)
+
+    def add_warning(self, element):
+        self.warning.append(element)
 
     def __repr__(self):
 
@@ -374,6 +375,7 @@ class Element(object):
         self.required = required
         self.annotation = []
         self.example = []
+        self.warning = []
         self.children = []
         self.attributes = []
         self.crumb = []
@@ -399,6 +401,9 @@ class Element(object):
 
     def add_example(self, element):
         self.example.append(element)
+
+    def add_warning(self, element):
+        self.warning.append(element)
 
     def add_attribute(self, attribute):
         self.attributes.append(attribute)
@@ -519,6 +524,8 @@ def walk_tree(xsd_element, stop_element, level=1, last_elem=None, context=None):
             for y in attrib.annotation.documentation:
                 for ex in y.findall("example"):
                     attr.add_example(ex)
+                for ex in y.findall("warning"):
+                    subElement.add_warning(ex)
                 if y.text is not None:
                     text = " ".join(y.text.split())
                     attr.add_annotation(text)
@@ -550,6 +557,8 @@ def walk_tree(xsd_element, stop_element, level=1, last_elem=None, context=None):
                         for y in e.annotation.documentation:
                             for ex in y.findall("example"):
                                 subElement.add_example(ex)
+                            for ex in y.findall("warning"):
+                                subElement.add_warning(ex)
                             if y.text != None:
                                 text = " ".join(y.text.split())
                                 subElement.add_annotation(text)

--- a/docs/convert_xsd_to_rst.py
+++ b/docs/convert_xsd_to_rst.py
@@ -163,6 +163,10 @@ def write_tree(element, outfile, first_time = True):
     for example in element.example:
         exampleStr = ""
         if isinstance(example, ElementTree.Element):
+            if example.get('ElementChoice') is not None and element.parent is not None:
+                if example.get('ElementChoice') != element.parent.name:
+                    # skip this example as wrong level
+                    continue
             if example.get('LevelChoice') is not None and element.parent is not None:
                 lc = example.get('LevelChoice')
                 level_char = element.crumb[0][0].upper()
@@ -206,8 +210,12 @@ def write_tree(element, outfile, first_time = True):
             description = ""
             example = ""
             if len(attrib.example) != 0:
+                # use first example unless ElementChoice is attribute of example
                 DQ='"'
                 example = f"{attrib.name}=\{DQ}{attrib.example[0].text}\{DQ}"
+                for ex in attrib.example:
+                    if ex.get("ElementChoice") is not None and ex.get("ElementChoice") == element.name:
+                        example = f"{attrib.name}=\{DQ}{ex.text}\{DQ}"
             for note in attrib.annotation:
                 old_note=note[:]
                 note=isRightChoice(note,element)

--- a/docs/convert_xsd_to_rst.py
+++ b/docs/convert_xsd_to_rst.py
@@ -92,7 +92,6 @@ def write_tree(element, outfile, first_time = True):
     if element.annotation:
         for note in element.annotation:
             old_note=note[:]
-            #note=choiceChooser(note,element)
             note=isRightChoice(note,element)
             if note:
                 if note==old_note:
@@ -171,7 +170,6 @@ def write_tree(element, outfile, first_time = True):
 
         # If the annotation involves multiple options depending on its location
 
-        #description=choiceChooser(description,element)
         description=urlInserter(description)
         description=mathBlock(description,element.level)
 
@@ -197,7 +195,6 @@ def write_tree(element, outfile, first_time = True):
         else:
             exampleStr = example
         exampleStr = exampleStr.strip()
-        #example=choiceChooser(example,element)
         print("   .. container:: example\n", file=outfile)
         if exampleStr.find('\n') != -1:
             # multiline example
@@ -229,7 +226,6 @@ def write_tree(element, outfile, first_time = True):
 
             for note in attrib.annotation:
                 old_note=note[:]
-                #note=choiceChooser(note,element)
                 note=isRightChoice(note,element)
                 if note:
 
@@ -268,27 +264,6 @@ def write_tree(element, outfile, first_time = True):
             write_tree(child, outfile, first_time = False)
 
     return
-
-
-# when given a documentation (Typically Example or Description) and the element, and it starts with default, will
-# return the correct documentation based off where it is in the xsd
-# Default:Default thing
-# Choice:N Documentation for network
-# Choice:S Documentation for station
-def choiceChooser(documentation,theElement):
-    if documentation.find("LevelDefault:")==0:
-        documentationChoices=documentation.split("LevelChoice:")
-        documentation=documentationChoices[0][13:]
-        sectionSymbol=theElement.crumb[0][0].upper()
-
-        for choice in documentationChoices[1:]:
-            if sectionSymbol==choice[0]:
-                documentation=choice[2:]
-    elif documentation.find("ElementDefault:")==0:
-        documentation=elementChoiceChooser(documentation,theElement)
-
-    return documentation
-
 
 def elementChoiceChooser(documentation,theElement):
     documentationChoices=documentation.split("ElementChoice:")

--- a/docs/convert_xsd_to_rst.py
+++ b/docs/convert_xsd_to_rst.py
@@ -187,6 +187,12 @@ def write_tree(element, outfile, first_time = True):
     for example in examples:
         exampleStr = ""
         if isinstance(example, ElementTree.Element):
+            if example.get('LevelChoice') is not None and element.parent is not None:
+                lc = example.get('LevelChoice')
+                level_char = element.crumb[0][0].upper()
+                if lc != level_char:
+                    # skip this example as wrong level
+                    continue
             if example.tag == "example":
                 for ee in example:
                     exampleStr += ElementTree.tostring(ee, encoding='unicode', method='xml')

--- a/docs/level-channel.rst
+++ b/docs/level-channel.rst
@@ -25,14 +25,14 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **alternateCode**, :ref:`string<type-glossary>`, no, "A code use for display or association", "" 
-      **code**, :ref:`string<type-glossary>`, :red:`yes`, "Name of Channel ", "code='BHZ'" 
-      **endDate**, :ref:`dateTime<type-glossary>`, no, "End date of channel epoch", "endDate=2018-01-27T00:00:00" 
-      **historicalCode**, :ref:`string<type-glossary>`, no, "LevelDefault:A previously used code if different from the current code", "" 
-      **locationCode**, :ref:`string<type-glossary>`, :red:`yes`, "The locationCode is typically used to group channels from a common sensor. For example, the channels of the primary sensor at global IDA-IRIS stations have locationCode = '00': 00_BHZ, 00_BHE, 00_BHN, 00_LHZ, ..., etc. Even though it is required, locationCode may be, and often is, an empty string, however, it is recommended that the locationCode not be empty.", "locationCode='30'" 
-      **restrictedStatus**, :ref:`RestrictedStatusType<type-glossary>`, no, "One of:'open', 'closed', 'partial'", "restrictedStatus='open'" 
-      **sourceID**, :ref:`anyURI<type-glossary>`, no, "A data source identifier in URI form", "sourceID='http://some/path'" 
-      **startDate**, :ref:`dateTime<type-glossary>`, no, "Start date of channel epoch", "startDate=2016-07-01T00:00:00" 
+      **alternateCode**, :ref:`string<type-glossary>`, no, "A code use for display or association", "alternateCode=\"Z\"" 
+      **code**, :ref:`string<type-glossary>`, :red:`yes`, "Name of Channel", "code=\"BHZ\"" 
+      **endDate**, :ref:`dateTime<type-glossary>`, no, "End date of channel epoch", "endDate=\"2018-01-27T00:00:00\"" 
+      **historicalCode**, :ref:`string<type-glossary>`, no, "LevelDefault:A previously used code if different from the current code", "historicalCode=\"bhz\"" 
+      **locationCode**, :ref:`string<type-glossary>`, :red:`yes`, "The locationCode is typically used to group channels from a common sensor. For example, the channels of the primary sensor at global IDA-IRIS stations have locationCode = \"00\": 00_BHZ, 00_BHE, 00_BHN, 00_LHZ, ..., etc. Even though it is required, locationCode may be, and often is, an empty string, however, it is recommended that the locationCode not be empty.", "locationCode=\"30\"" 
+      **restrictedStatus**, :ref:`RestrictedStatusType<type-glossary>`, no, "One of: \"open\", \"closed\", \"partial\"", "restrictedStatus=\"open\"" 
+      **sourceID**, :ref:`anyURI<type-glossary>`, no, "A data source identifier in URI form", "sourceID=\"http://some/path\"" 
+      **startDate**, :ref:`dateTime<type-glossary>`, no, "Start date of channel epoch", "startDate=\"2016-07-01T00:00:00\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -100,7 +100,7 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **type**, :ref:`string<type-glossary>`, no, "Identifier type", "type='DOI'" 
+      **type**, :ref:`string<type-glossary>`, no, "Identifier type", "type=\"DOI\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -127,8 +127,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **id**, :ref:`CounterType<type-glossary>`, no, "An ID for this comment", "id=12345" 
-      **subject**, :ref:`string<type-glossary>`, no, "A subject for this comment. Multiple comments with the same subject should be considered related.", "subject='Scheduled maintenance'" 
+      **id**, :ref:`CounterType<type-glossary>`, no, "An ID for this comment", "id=\"12345\"" 
+      **subject**, :ref:`string<type-glossary>`, no, "A subject for this comment. Multiple comments with the same subject should be considered related.", "subject=\"Scheduled maintenance\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -238,7 +238,7 @@
 
    .. container:: description
 
-      Author of Comment.
+      Author of Comment. Person's contact information. A person can belong to multiple agencies and have multiple email addresses and phone numbers.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -420,7 +420,7 @@
 
    .. container:: example
 
-      **Example**: <AreaCode>408</CountryCode>
+      **Example**: <AreaCode>408</AreaCode>
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -468,7 +468,7 @@
 
    .. container:: description
 
-      A description of time series data availability. This information should be considered transient and is primarily useful as a guide for generating time series data requests. The information for a DataAvailability:Span may be specific to the time range used in a request that resulted in the document or limited to the availability of data within the request range. These details may or may not be retained when synchronizing metadata between data centers.
+      A description of time series data availability. This information should be considered transient and is primarily useful as a guide for generating time series data requests. The information for a DataAvailability:Span may be specific to the time range used in a request that resulted in the document or limited to the availability of data within the request range. These details may or may not be retained when synchronizing metadata between data centers. A type for describing data availability.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -495,8 +495,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **end**, :ref:`dateTime<type-glossary>`, :red:`yes`, "end date of extent", "end=1988-12-31T00:00:00" 
-      **start**, :ref:`dateTime<type-glossary>`, :red:`yes`, "start date of extent", "start=1988-01-01T00:00:00" 
+      **end**, :ref:`dateTime<type-glossary>`, :red:`yes`, "end date of extent", "end=\"1988-12-31T00:00:00\"" 
+      **start**, :ref:`dateTime<type-glossary>`, :red:`yes`, "start date of extent", "start=\"1988-01-01T00:00:00\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -523,10 +523,10 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **end**, :ref:`dateTime<type-glossary>`, :red:`yes`, "end date of span", "end=1988-12-31T00:00:00" 
-      **maximumTimeTear**, :ref:`decimal<type-glossary>`, no, "The maximum time tear (gap or overlap) in seconds between time series segments in the specified range.", "maximumTimeTear=0.01" 
-      **numberSegments**, :ref:`integer<type-glossary>`, :red:`yes`, "The number of continuous time series segments contained in the specified time range. A value of 1 indicates that the time series is continuous from start to end.", "numberSegments=2" 
-      **start**, :ref:`dateTime<type-glossary>`, :red:`yes`, "start date of span", "start=1988-01-01T00:00:00" 
+      **end**, :ref:`dateTime<type-glossary>`, :red:`yes`, "end date of span", "end=\"1988-12-31T00:00:00\"" 
+      **maximumTimeTear**, :ref:`decimal<type-glossary>`, no, "The maximum time tear (gap or overlap) in seconds between time series segments in the specified range.", "maximumTimeTear=\"0.01\"" 
+      **numberSegments**, :ref:`integer<type-glossary>`, :red:`yes`, "The number of continuous time series segments contained in the specified time range. A value of 1 indicates that the time series is continuous from start to end.", "numberSegments=\"2\"" 
+      **start**, :ref:`dateTime<type-glossary>`, :red:`yes`, "start date of span", "start=\"1988-01-01T00:00:00\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -543,7 +543,7 @@
 
    .. container:: description
 
-      URI of any type of external report, such as data quality reports.
+      URI of any type of external report, such as data quality reports. This type contains a Uniform Resource Identifier (URI) and and description for external information that users may want to reference.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -624,7 +624,7 @@
 
    .. container:: description
 
-      Latitude of this channel's sensor, by default in degrees. Often the same as the station latitude, but when different the channel latitude is the true location of the sensor.
+      Latitude of this channel's sensor, by default in degrees. Often the same as the station latitude, but when different the channel latitude is the true location of the sensor. Latitude type extending the base type to add datum as an attribute with default.
 
    .. container:: example
 
@@ -638,9 +638,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='DEGREES'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"DEGREES\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
       **datum**, :ref:`NMTOKEN<type-glossary>`, no, "", "" 
 
@@ -669,7 +669,7 @@
 
    .. container:: description
 
-      Longitude of this channel's sensor, by default in degrees. Often the same as the station longitude, but when different the channel longitude is the true location of the sensor.
+      Longitude of this channel's sensor, by default in degrees. Often the same as the station longitude, but when different the channel longitude is the true location of the sensor. Longitude type extending the base type to add datum as an attribute with default.
 
    .. container:: example
 
@@ -683,9 +683,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='DEGREES'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"DEGREES\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
       **datum**, :ref:`NMTOKEN<type-glossary>`, no, "", "" 
 
@@ -714,7 +714,7 @@
 
    .. container:: description
 
-      Elevation of the sensor, by default in meters. To find the local ground surface level, add the Depth value to this elevation.
+      Elevation of the sensor, by default in meters. To find the local ground surface level, add the Depth value to this elevation. Extension of FloatType for distances, elevations, and depths.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -724,9 +724,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='m'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"m\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -754,7 +754,7 @@
 
    .. container:: description
 
-      The depth of the sensor relative to the local ground surface level, in meters.
+      The depth of the sensor relative to the local ground surface level, in meters. Extension of FloatType for distances, elevations, and depths.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -764,9 +764,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='m'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"m\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -794,7 +794,7 @@
 
    .. container:: description
 
-      Azimuth of the sensor in degrees clockwise from geographic (true) north.
+      Azimuth of the sensor in degrees clockwise from geographic (true) north. Instrument azimuth, degrees clockwise from North.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -804,9 +804,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='DEGREES'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"DEGREES\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -834,7 +834,7 @@
 
    .. container:: description
 
-      Dip of the instrument in degrees, positive down from horizontal.
+      Dip of the instrument in degrees, positive down from horizontal Instrument dip in degrees, positive down from horizontal.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -844,9 +844,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='DEGREES'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"DEGREES\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -874,7 +874,7 @@
 
    .. container:: description
 
-      Elevation of the water surface in meters for underwater sites, where 0 is mean sea level. If you put an OBS on a lake bottom, where the lake surface is at elevation=0, then you should set WaterLevel=0.
+      Elevation of the water surface in meters for underwater sites, where 0 is mean sea level. If you put an OBS on a lake bottom, where the lake surface is at elevation=0, then you should set WaterLevel=0. Representation of floating-point numbers used as measurements.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -884,9 +884,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The unit of measurement. Use *SI* unit names and symbols whenever possible (e.g., 'm' instead of 'METERS').", "unit='m'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The unit of measurement. Use *SI* unit names and symbols whenever possible (e.g., 'm' instead of 'METERS').", "unit=\"m\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -943,13 +943,9 @@
 
 					type:`double <appendices.html#glossary-double>`_
 
-   .. container:: description
-
-      Sample rate in samples per second. SampleRate is optional unless SampleRateRatio is present, in which case SampleRate is required.
-
    .. container:: example
 
-      **Example**: <SampleRate units='SAMPLES/S'>40.0</SampleRate>
+      **Example**: <SampleRate units="SAMPLES/S">40.0</SampleRate>
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -959,9 +955,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='SAMPLES/S'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"SAMPLES/S\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -977,14 +973,15 @@
 
       Channel :raw-html:`&rarr;`:raw-latex:`$\rightarrow$` SampleRateRatio
 
-   .. container:: description
-
-      Sample rate expressed as number of samples in a number of seconds. If present, then <SampleRate> must also be present. It can be useful for very slow data (e.g., greater than 10 days), since it allows for greater precision in the stored value.
-
    .. container:: example
 
-      **Example**: <SampleRate>3.859999367e-07</SampleRate> <SampleRateRatio><NumberSamples>1</NumberSamples> <NumberSeconds>2590674</NumberSeconds> </SampleRateRatio>
+      **Example**::
 
+        <SampleRate>3.859999367e-07</SampleRate>
+        <SampleRateRatio>
+        	<NumberSamples>1</NumberSamples>
+        	<NumberSeconds>2590674</NumberSeconds>
+        </SampleRateRatio>
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
 
@@ -1074,9 +1071,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The unit of drift value.", "unit='SECONDS/SAMPLE'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The unit of drift value.", "unit=\"SECONDS/SAMPLE\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -1094,12 +1091,16 @@
 
    .. container:: description
 
-      Units of calibration (e.g., V (for Volts) or A (for amps)).
+      Units of calibration (e.g., V (for Volts) or A (for amps)) Use *SI* units when possible A type to document units; use SI whenever possible.
 
    .. container:: example
 
-      **Example**:  <CalibrationUnits><Name>V</Name> <Description>Volts</Description> </CalibrationUnits>
+      **Example**::
 
+        <CalibrationUnits>
+          <Name>V</Name>
+          <Description>Volts</Description>
+        </CalibrationUnits>
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
 
@@ -1169,7 +1170,7 @@
 
    .. container:: description
 
-      Details of the (typically analog) sensor attached to this channel. If this was entered at the Station level, it is not necessary to do it for each Channel, unless you have differences in equipment.
+      Details of the (typically analog) sensor attached to this channel. If this was entered at the Station level, it is not necessary to do it for each Channel, unless you have differences in equipment. A type for equipment related to data acquisition or processing.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -1439,7 +1440,7 @@
 
    .. container:: description
 
-      Preamplifier (if any) used by this channel. If this was entered at the Station level, it is not necessary to do it for each Channel, unless you have differences in equipment.
+      Preamplifier (if any) used by this channel. If this was entered at the Station level, it is not necessary to do it for each Channel, unless you have differences in equipment. A type for equipment related to data acquisition or processing.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -1709,7 +1710,7 @@
 
    .. container:: description
 
-      Datalogger that recorded this channel. If this was entered at the Station level, it is not necessary to do it for each Channel, unless you have differences in equipment.
+      Datalogger that recorded this channel. If this was entered at the Station level, it is not necessary to do it for each Channel, unless you have differences in equipment. A type for equipment related to data acquisition or processing.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -1979,7 +1980,7 @@
 
    .. container:: description
 
-      If the Equipment is entered at the Station level, it is not necessary to do it for each Channel, unless you have differences in equipment. If using a preamplifier, sensor, or datalogger, use their appropriate fields instead.
+      If the Equipment is entered at the Station level, it is not necessary to do it for each Channel, unless you have differences in equipment. If using a preamplifier, sensor, or datalogger, use their appropriate fields instead. A type for equipment related to data acquisition or processing.
 
 .. tabularcolumns::|l|l|l|1|1| 
 

--- a/docs/level-network.rst
+++ b/docs/level-network.rst
@@ -19,7 +19,7 @@
 
    .. container:: example
 
-      **Example**: <Network code="IU" startDate=2016-01-27T13:00:00>
+      **Example**: <Network code="IU" startDate="2016-01-27T13:00:00" />
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -29,13 +29,13 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **alternateCode**, :ref:`string<type-glossary>`, no, "A code use for display or association", "alternateCode='GSN' " 
-      **code**, :ref:`string<type-glossary>`, :red:`yes`, "Name of Network ", "code='IU'" 
-      **endDate**, :ref:`dateTime<type-glossary>`, no, "End date of network", "endDate=2018-01-27T00:00:00" 
-      **historicalCode**, :ref:`string<type-glossary>`, no, "LevelDefault:A previously used code if different from the current code", "historicalCode='II' " 
-      **restrictedStatus**, :ref:`RestrictedStatusType<type-glossary>`, no, "One of:'open', 'closed', 'partial'", "restrictedStatus='open'" 
-      **sourceID**, :ref:`anyURI<type-glossary>`, no, "A data source identifier in URI form", "sourceID='http://some/path'" 
-      **startDate**, :ref:`dateTime<type-glossary>`, no, "Start date of network", "startDate=2016-07-01T00:00:00" 
+      **alternateCode**, :ref:`string<type-glossary>`, no, "A code use for display or association", "alternateCode=\"GSN\"" 
+      **code**, :ref:`string<type-glossary>`, :red:`yes`, "Name of Network", "code=\"IU\"" 
+      **endDate**, :ref:`dateTime<type-glossary>`, no, "End date of network", "endDate=\"2018-01-27T00:00:00\"" 
+      **historicalCode**, :ref:`string<type-glossary>`, no, "LevelDefault:A previously used code if different from the current code", "historicalCode=\"II\"" 
+      **restrictedStatus**, :ref:`RestrictedStatusType<type-glossary>`, no, "One of: \"open\", \"closed\", \"partial\"", "restrictedStatus=\"open\"" 
+      **sourceID**, :ref:`anyURI<type-glossary>`, no, "A data source identifier in URI form", "sourceID=\"http://some/path\"" 
+      **startDate**, :ref:`dateTime<type-glossary>`, no, "Start date of network", "startDate=\"2016-07-01T00:00:00\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -103,7 +103,7 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **type**, :ref:`string<type-glossary>`, no, "Identifier type", "type='DOI'" 
+      **type**, :ref:`string<type-glossary>`, no, "Identifier type", "type=\"DOI\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -130,8 +130,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **id**, :ref:`CounterType<type-glossary>`, no, "An ID for this comment", "id=12345" 
-      **subject**, :ref:`string<type-glossary>`, no, "A subject for this comment. Multiple comments with the same subject should be considered related.", "subject='Scheduled maintenance'" 
+      **id**, :ref:`CounterType<type-glossary>`, no, "An ID for this comment", "id=\"12345\"" 
+      **subject**, :ref:`string<type-glossary>`, no, "A subject for this comment. Multiple comments with the same subject should be considered related.", "subject=\"Scheduled maintenance\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -241,7 +241,7 @@
 
    .. container:: description
 
-      Author of Comment.
+      Author of Comment. Person's contact information. A person can belong to multiple agencies and have multiple email addresses and phone numbers.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -423,7 +423,7 @@
 
    .. container:: example
 
-      **Example**: <AreaCode>408</CountryCode>
+      **Example**: <AreaCode>408</AreaCode>
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -471,7 +471,7 @@
 
    .. container:: description
 
-      A description of time series data availability. This information should be considered transient and is primarily useful as a guide for generating time series data requests. The information for a DataAvailability:Span may be specific to the time range used in a request that resulted in the document or limited to the availability of data within the request range. These details may or may not be retained when synchronizing metadata between data centers.
+      A description of time series data availability. This information should be considered transient and is primarily useful as a guide for generating time series data requests. The information for a DataAvailability:Span may be specific to the time range used in a request that resulted in the document or limited to the availability of data within the request range. These details may or may not be retained when synchronizing metadata between data centers. A type for describing data availability.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -498,8 +498,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **end**, :ref:`dateTime<type-glossary>`, :red:`yes`, "end date of extent", "end=1988-12-31T00:00:00" 
-      **start**, :ref:`dateTime<type-glossary>`, :red:`yes`, "start date of extent", "start=1988-01-01T00:00:00" 
+      **end**, :ref:`dateTime<type-glossary>`, :red:`yes`, "end date of extent", "end=\"1988-12-31T00:00:00\"" 
+      **start**, :ref:`dateTime<type-glossary>`, :red:`yes`, "start date of extent", "start=\"1988-01-01T00:00:00\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -526,10 +526,10 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **end**, :ref:`dateTime<type-glossary>`, :red:`yes`, "end date of span", "end=1988-12-31T00:00:00" 
-      **maximumTimeTear**, :ref:`decimal<type-glossary>`, no, "The maximum time tear (gap or overlap) in seconds between time series segments in the specified range.", "maximumTimeTear=0.01" 
-      **numberSegments**, :ref:`integer<type-glossary>`, :red:`yes`, "The number of continuous time series segments contained in the specified time range. A value of 1 indicates that the time series is continuous from start to end.", "numberSegments=2" 
-      **start**, :ref:`dateTime<type-glossary>`, :red:`yes`, "start date of span", "start=1988-01-01T00:00:00" 
+      **end**, :ref:`dateTime<type-glossary>`, :red:`yes`, "end date of span", "end=\"1988-12-31T00:00:00\"" 
+      **maximumTimeTear**, :ref:`decimal<type-glossary>`, no, "The maximum time tear (gap or overlap) in seconds between time series segments in the specified range.", "maximumTimeTear=\"0.01\"" 
+      **numberSegments**, :ref:`integer<type-glossary>`, :red:`yes`, "The number of continuous time series segments contained in the specified time range. A value of 1 indicates that the time series is continuous from start to end.", "numberSegments=\"2\"" 
+      **start**, :ref:`dateTime<type-glossary>`, :red:`yes`, "start date of span", "start=\"1988-01-01T00:00:00\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -546,7 +546,7 @@
 
    .. container:: description
 
-      Agency and contact persons who manage this network.
+      Agency and contact persons who manage this network. An operating agency and associated contact persons. Since the Contact element is a generic type that represents any contact person, it also has its own optional Agency element. It is expected that typically the contact’s optional Agency tag will match the Operator Agency. Only contacts appropriate for the enclosing element should be include in the Operator tag.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -776,7 +776,7 @@
 
    .. container:: example
 
-      **Example**: <AreaCode>408</CountryCode>
+      **Example**: <AreaCode>408</AreaCode>
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`

--- a/docs/level-preamble.rst
+++ b/docs/level-preamble.rst
@@ -25,7 +25,7 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **schemaVersion**, :ref:`decimal<type-glossary>`, :red:`yes`, "The StationXML schema version of this document.", "schemaVersion='1.1'" 
+      **schemaVersion**, :ref:`decimal<type-glossary>`, :red:`yes`, "The StationXML schema version of this document.", "schemaVersion=\"1.1\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`

--- a/docs/level-response.rst
+++ b/docs/level-response.rst
@@ -42,7 +42,7 @@
 
    .. container:: description
 
-      The total sensitivity for a channel, representing the complete acquisition system expressed as a scalar. All instrument responses except polynomial response should have an InstrumentSensitivity.
+      The total sensitivity for a channel, representing the complete acquisition system expressed as a scalar. All instrument responses except polynomial response should have an InstrumentSensitivity. Type for sensitivity, input/output units and relevant frequency range.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -113,7 +113,7 @@
 
    .. container:: description
 
-      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units.
+      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -184,7 +184,7 @@
 
    .. container:: description
 
-      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response.
+      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -343,7 +343,7 @@
 
 			\begin{eqnarray}Temp(V)=\sum_{k=0}^{N} a_k V^{k}\end{eqnarray}
 
-		For such responses, two StationXML components are required to specify the response: 1. A Polynomial stage, which contains the values of the Maclaurin coefficients, :math:`a_k`, and 2. An InstrumentPolynomial element that contains the same coefficients, but scaled by powers of the overall gain representing the combined effect of all the stages in the complete acquisition system.
+		For such responses, two StationXML components are required to specify the response: 1. A Polynomial stage, which contains the values of the Maclaurin coefficients, :math:`a_k`, and 2. An InstrumentPolynomial element that contains the same coefficients, but scaled by powers of the overall gain representing the combined effect of all the stages in the complete acquisition system. Response type for a reponse represented as a polynomial expansion, which allows non-linear sensors to be described. Used at either a stage of acquisition response or a complete system.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -398,7 +398,7 @@
 
    .. container:: description
 
-      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units.
+      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -469,7 +469,7 @@
 
    .. container:: description
 
-      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response.
+      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -587,9 +587,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='HERTZ'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"HERTZ\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -627,9 +627,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='HERTZ'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"HERTZ\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -744,8 +744,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
       **number**, :ref:`CounterType<type-glossary>`, no, "", "" 
 
@@ -847,7 +847,7 @@
 
    .. container:: description
 
-      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units.
+      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -918,7 +918,7 @@
 
    .. container:: description
 
-      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response.
+      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -1003,7 +1003,7 @@
 
    .. container:: example
 
-     **Example**:  <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>".
+      **Example**: <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -1067,9 +1067,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='HERTZ'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"HERTZ\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -1097,7 +1097,7 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **number**, :ref:`integer<type-glossary>`, no, "The position index of the pole (or zero) in the array of poles[] (or zeros[])", "<Pole number='1'>" 
+      **number**, :ref:`integer<type-glossary>`, no, "The position index of the pole (or zero) in the array of poles[] (or zeros[])", "number=\"None\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -1124,7 +1124,7 @@
 
    .. container:: description
 
-      Real part of the pole or zero.
+      Real part of the pole or zero. Representation of floating-point numbers without unit.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -1134,8 +1134,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -1163,7 +1163,7 @@
 
    .. container:: description
 
-      Imaginary part of the pole or zero.
+      Imaginary part of the pole or zero. Representation of floating-point numbers without unit.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -1173,8 +1173,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -1202,7 +1202,7 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **number**, :ref:`integer<type-glossary>`, no, "The position index of the pole (or zero) in the array of poles[] (or zeros[])", "<Pole number='1'>" 
+      **number**, :ref:`integer<type-glossary>`, no, "The position index of the pole (or zero) in the array of poles[] (or zeros[])", "number=\"None\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -1229,7 +1229,7 @@
 
    .. container:: description
 
-      Real part of the pole or zero.
+      Real part of the pole or zero. Representation of floating-point numbers without unit.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -1239,8 +1239,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -1268,7 +1268,7 @@
 
    .. container:: description
 
-      Imaginary part of the pole or zero.
+      Imaginary part of the pole or zero. Representation of floating-point numbers without unit.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -1278,8 +1278,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -1352,7 +1352,7 @@
 
    .. container:: description
 
-      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units.
+      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -1423,7 +1423,7 @@
 
    .. container:: description
 
-      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response.
+      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -1541,8 +1541,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
       **number**, :ref:`CounterType<type-glossary>`, no, "", "" 
 
@@ -1581,8 +1581,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
       **number**, :ref:`CounterType<type-glossary>`, no, "", "" 
 
@@ -1656,7 +1656,7 @@
 
    .. container:: description
 
-      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units.
+      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -1727,7 +1727,7 @@
 
    .. container:: description
 
-      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response.
+      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -1827,9 +1827,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='HERTZ'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"HERTZ\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -1867,9 +1867,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The unit of measurement. Use *SI* unit names and symbols whenever possible (e.g., 'm' instead of 'METERS').", "unit='m'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The unit of measurement. Use *SI* unit names and symbols whenever possible (e.g., 'm' instead of 'METERS').", "unit=\"m\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -1903,9 +1903,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='DEGREES'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"DEGREES\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -1978,7 +1978,7 @@
 
    .. container:: description
 
-      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units.
+      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -2049,7 +2049,7 @@
 
    .. container:: description
 
-      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response.
+      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -2209,9 +2209,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='HERTZ'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"HERTZ\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -2293,7 +2293,7 @@
 
    .. container:: description
 
-      The estimated pure delay for the stage. This value will almost always be positive to indicate a delayed signal. Due to the difficulty in estimating the pure delay of a stage and because dispersion is neglected, this value should be considered nominal. Normally the delay would be corrected by the recording system and the correction applied would be specified in <Correction> below. See the Decimation Section in the StationXML documentation for a schematic description of delay sign convention.
+      The estimated pure delay for the stage. This value will almost always be positive to indicate a delayed signal. Due to the difficulty in estimating the pure delay of a stage and because dispersion is neglected, this value should be considered nominal. Normally the delay would be corrected by the recording system and the correction applied would be specified in <Correction> below. See the Decimation Section in the StationXML documentation for a schematic description of delay sign convention. Representation of floating-point numbers used as measurements.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -2303,9 +2303,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The unit of measurement. Use *SI* unit names and symbols whenever possible (e.g., 'm' instead of 'METERS').", "unit='SECONDS'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The unit of measurement. Use *SI* unit names and symbols whenever possible (e.g., 'm' instead of 'METERS').", "unit=\"SECONDS\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -2333,7 +2333,7 @@
 
    .. container:: description
 
-      The time shift, if any, applied to correct for the delay at this stage. The sign convention used is opposite the <Delay> value; a positive sign here indicates that the trace was corrected to an earlier time to cancel the delay caused by the stage and indicated in the <Delay> element. Commonly, the estimated delay and the applied correction are both positive to cancel each other. A value of zero indicates no correction was applied. See the Decimation Section in the StationXML documentation for a schematic description of delay sign convention.
+      The time shift, if any, applied to correct for the delay at this stage. The sign convention used is opposite the <Delay> value; a positive sign here indicates that the trace was corrected to an earlier time to cancel the delay caused by the stage and indicated in the <Delay> element. Commonly, the estimated delay and the applied correction are both positive to cancel each other. A value of zero indicates no correction was applied. See the Decimation Section in the StationXML documentation for a schematic description of delay sign convention. Representation of floating-point numbers used as measurements.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -2343,9 +2343,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The unit of measurement. Use *SI* unit names and symbols whenever possible (e.g., 'm' instead of 'METERS').", "unit='SECONDS'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The unit of measurement. Use *SI* unit names and symbols whenever possible (e.g., 'm' instead of 'METERS').", "unit=\"SECONDS\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -2363,7 +2363,7 @@
 
    .. container:: description
 
-      The gain at the stage of the encapsulating response element at a specific frequency. Total channel sensitivity should be specified in the InstrumentSensitivity element.
+      The gain at the stage of the encapsulating response element at a specific frequency. Total channel sensitivity should be specified in the InstrumentSensitivity element. Type used for representing sensitivity at a given frequency. This complex type can be used to represent both total sensitivities and individual stage gains.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -2434,7 +2434,7 @@
 
    .. container:: description
 
-      When a response is given in terms of a polynomial expansion of powers of the sensor output signal (e.g., Volts), a Polynomial Stage is required to specify the Maclaurin coefficients of the expansion. In addition, an InstrumentPolynomial element must be present at Response level to represent the whole acquisition process, which contains the same Maclaurin coefficients, but scaled by powers of the overall gain for all stages.
+      When a response is given in terms of a polynomial expansion of powers of the sensor output signal (e.g., Volts), a Polynomial Stage is required to specify the Maclaurin coefficients of the expansion. In addition, an InstrumentPolynomial element must be present at Response level to represent the whole acquisition process, which contains the same Maclaurin coefficients, but scaled by powers of the overall gain for all stages. Response type for a reponse represented as a polynomial expansion, which allows non-linear sensors to be described. Used at either a stage of acquisition response or a complete system.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -2489,7 +2489,7 @@
 
    .. container:: description
 
-      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units.
+      The units of the data as input from the perspective of data acquisition. After correcting data for this response, these would be the resulting units. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -2560,7 +2560,7 @@
 
    .. container:: description
 
-      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response.
+      The units of the data as output from the perspective of data acquisition. These would be the units of the data prior to correcting for this response. A type to document units; use SI whenever possible.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -2678,9 +2678,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='HERTZ'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"HERTZ\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -2718,9 +2718,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='HERTZ'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"HERTZ\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -2835,8 +2835,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
       **number**, :ref:`CounterType<type-glossary>`, no, "", "" 
 

--- a/docs/level-station.rst
+++ b/docs/level-station.rst
@@ -25,13 +25,13 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **alternateCode**, :ref:`string<type-glossary>`, no, "A code use for display or association", "" 
-      **code**, :ref:`string<type-glossary>`, :red:`yes`, "Name of Station ", "code='ANMO'" 
-      **endDate**, :ref:`dateTime<type-glossary>`, no, "End date of station epoch", "endDate=2018-01-27T00:00:00" 
-      **historicalCode**, :ref:`string<type-glossary>`, no, "LevelDefault:A previously used code if different from the current code", "" 
-      **restrictedStatus**, :ref:`RestrictedStatusType<type-glossary>`, no, "One of:'open', 'closed', 'partial'", "restrictedStatus='open'" 
-      **sourceID**, :ref:`anyURI<type-glossary>`, no, "A data source identifier in URI form", "sourceID='http://some/path'" 
-      **startDate**, :ref:`dateTime<type-glossary>`, no, "Start date of station epoch", "startDate=2016-07-01T00:00:00" 
+      **alternateCode**, :ref:`string<type-glossary>`, no, "A code use for display or association", "alternateCode=\"ALQ\"" 
+      **code**, :ref:`string<type-glossary>`, :red:`yes`, "Name of Station", "code=\"ANMO\"" 
+      **endDate**, :ref:`dateTime<type-glossary>`, no, "End date of station epoch", "endDate=\"2018-01-27T00:00:00\"" 
+      **historicalCode**, :ref:`string<type-glossary>`, no, "LevelDefault:A previously used code if different from the current code", "historicalCode=\"albq\"" 
+      **restrictedStatus**, :ref:`RestrictedStatusType<type-glossary>`, no, "One of: \"open\", \"closed\", \"partial\"", "restrictedStatus=\"open\"" 
+      **sourceID**, :ref:`anyURI<type-glossary>`, no, "A data source identifier in URI form", "sourceID=\"http://some/path\"" 
+      **startDate**, :ref:`dateTime<type-glossary>`, no, "Start date of station epoch", "startDate=\"2016-07-01T00:00:00\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -99,7 +99,7 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **type**, :ref:`string<type-glossary>`, no, "Identifier type", "type='DOI'" 
+      **type**, :ref:`string<type-glossary>`, no, "Identifier type", "type=\"DOI\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -126,8 +126,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **id**, :ref:`CounterType<type-glossary>`, no, "An ID for this comment", "id=12345" 
-      **subject**, :ref:`string<type-glossary>`, no, "A subject for this comment. Multiple comments with the same subject should be considered related.", "subject='Scheduled maintenance'" 
+      **id**, :ref:`CounterType<type-glossary>`, no, "An ID for this comment", "id=\"12345\"" 
+      **subject**, :ref:`string<type-glossary>`, no, "A subject for this comment. Multiple comments with the same subject should be considered related.", "subject=\"Scheduled maintenance\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -237,7 +237,7 @@
 
    .. container:: description
 
-      Author of Comment.
+      Author of Comment. Person's contact information. A person can belong to multiple agencies and have multiple email addresses and phone numbers.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -419,7 +419,7 @@
 
    .. container:: example
 
-      **Example**: <AreaCode>408</CountryCode>
+      **Example**: <AreaCode>408</AreaCode>
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -467,7 +467,7 @@
 
    .. container:: description
 
-      A description of time series data availability. This information should be considered transient and is primarily useful as a guide for generating time series data requests. The information for a DataAvailability:Span may be specific to the time range used in a request that resulted in the document or limited to the availability of data within the request range. These details may or may not be retained when synchronizing metadata between data centers.
+      A description of time series data availability. This information should be considered transient and is primarily useful as a guide for generating time series data requests. The information for a DataAvailability:Span may be specific to the time range used in a request that resulted in the document or limited to the availability of data within the request range. These details may or may not be retained when synchronizing metadata between data centers. A type for describing data availability.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -494,8 +494,8 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **end**, :ref:`dateTime<type-glossary>`, :red:`yes`, "end date of extent", "end=1988-12-31T00:00:00" 
-      **start**, :ref:`dateTime<type-glossary>`, :red:`yes`, "start date of extent", "start=1988-01-01T00:00:00" 
+      **end**, :ref:`dateTime<type-glossary>`, :red:`yes`, "end date of extent", "end=\"1988-12-31T00:00:00\"" 
+      **start**, :ref:`dateTime<type-glossary>`, :red:`yes`, "start date of extent", "start=\"1988-01-01T00:00:00\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -522,10 +522,10 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **end**, :ref:`dateTime<type-glossary>`, :red:`yes`, "end date of span", "end=1988-12-31T00:00:00" 
-      **maximumTimeTear**, :ref:`decimal<type-glossary>`, no, "The maximum time tear (gap or overlap) in seconds between time series segments in the specified range.", "maximumTimeTear=0.01" 
-      **numberSegments**, :ref:`integer<type-glossary>`, :red:`yes`, "The number of continuous time series segments contained in the specified time range. A value of 1 indicates that the time series is continuous from start to end.", "numberSegments=2" 
-      **start**, :ref:`dateTime<type-glossary>`, :red:`yes`, "start date of span", "start=1988-01-01T00:00:00" 
+      **end**, :ref:`dateTime<type-glossary>`, :red:`yes`, "end date of span", "end=\"1988-12-31T00:00:00\"" 
+      **maximumTimeTear**, :ref:`decimal<type-glossary>`, no, "The maximum time tear (gap or overlap) in seconds between time series segments in the specified range.", "maximumTimeTear=\"0.01\"" 
+      **numberSegments**, :ref:`integer<type-glossary>`, :red:`yes`, "The number of continuous time series segments contained in the specified time range. A value of 1 indicates that the time series is continuous from start to end.", "numberSegments=\"2\"" 
+      **start**, :ref:`dateTime<type-glossary>`, :red:`yes`, "start date of span", "start=\"1988-01-01T00:00:00\"" 
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -552,7 +552,7 @@
 
    .. container:: description
 
-      Station latitude, by default in degrees. Where the bulk of the equipment is located (or another appropriate site location).
+      Station latitude, by default in degrees. Where the bulk of the equipment is located (or another appropriate site location). Latitude type extending the base type to add datum as an attribute with default.
 
    .. container:: example
 
@@ -566,9 +566,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='DEGREES'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"DEGREES\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
       **datum**, :ref:`NMTOKEN<type-glossary>`, no, "", "" 
 
@@ -597,7 +597,7 @@
 
    .. container:: description
 
-      Station longitude, by default in degrees. Where the bulk of the equipment is located (or another appropriate site location).
+      Station longitude, by default in degrees. Where the bulk of the equipment is located (or another appropriate site location). Longitude type extending the base type to add datum as an attribute with default.
 
    .. container:: example
 
@@ -611,9 +611,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='DEGREES'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"DEGREES\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
       **datum**, :ref:`NMTOKEN<type-glossary>`, no, "", "" 
 
@@ -642,7 +642,7 @@
 
    .. container:: description
 
-      Elevation of local ground surface level at station, by default in meters.
+      Elevation of local ground surface level at station, by default in meters. Extension of FloatType for distances, elevations, and depths.
 
    .. container:: example
 
@@ -656,9 +656,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit='m'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The type of unit being used.", "unit=\"m\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -676,7 +676,7 @@
 
    .. container:: description
 
-      Description of the location of the station using geopolitical entities (country, city, etc.).
+      Description of the location of the station using geopolitical entities (country, city, etc.). Description of a site location using name and optional geopolitical boundaries (country, city, etc.).
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -889,7 +889,7 @@
 
    .. container:: description
 
-      Elevation of the water surface (in meters) for underwater sites, where 0 is mean sea level. If you put an ocean-bottom seismometer (OBS) on a lake bottom, where the lake surface is at elevation=0, then you should set WaterLevel=0.
+      Elevation of the water surface (in meters) for underwater sites, where 0 is mean sea level. If you put an ocean-bottom seismometer (OBS) on a lake bottom, where the lake surface is at elevation=0, then you should set WaterLevel=0. Representation of floating-point numbers used as measurements.
 
    .. container:: example
 
@@ -903,9 +903,9 @@
       :header: "attribute", "type", "required", "description", "example"
       :widths: auto
 
-      **unit**, :ref:`string<type-glossary>`, no, "The unit of measurement. Use *SI* unit names and symbols whenever possible (e.g., 'm' instead of 'METERS').", "unit='m'" 
-      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=0.1" 
-      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=0.1" 
+      **unit**, :ref:`string<type-glossary>`, no, "The unit of measurement. Use *SI* unit names and symbols whenever possible (e.g., 'm' instead of 'METERS').", "unit=\"m\"" 
+      **plusError**, :ref:`double<type-glossary>`, no, "plus uncertainty or error in measured value.", "plusError=\"0.1\"" 
+      **minusError**, :ref:`double<type-glossary>`, no, "minus uncertainty or error in measured value.", "minusError=\"0.1\"" 
       **measurementMethod**, :ref:`string<type-glossary>`, no, "", "" 
 
 
@@ -977,7 +977,7 @@
 
    .. container:: description
 
-      Equipment used by all channels at a station.
+      Equipment used by all channels at a station. A type for equipment related to data acquisition or processing.
 
 .. tabularcolumns::|l|l|l|1|1| 
 
@@ -1247,7 +1247,7 @@
 
    .. container:: description
 
-      Operator and associated contact persons.
+      Operator and associated contact persons An operating agency and associated contact persons. Since the Contact element is a generic type that represents any contact person, it also has its own optional Agency element. It is expected that typically the contact’s optional Agency tag will match the Operator Agency. Only contacts appropriate for the enclosing element should be include in the Operator tag.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -1477,7 +1477,7 @@
 
    .. container:: example
 
-      **Example**: <AreaCode>408</CountryCode>
+      **Example**: <AreaCode>408</AreaCode>
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`
@@ -1680,7 +1680,7 @@
 
    .. container:: description
 
-      URI of any type of external report.
+      URI of any type of external report This type contains a Uniform Resource Identifier (URI) and and description for external information that users may want to reference.
 
 
 :raw-latex:`\noindent\rule{\textwidth}{1pt}`

--- a/docs/schema-keywords.rst
+++ b/docs/schema-keywords.rst
@@ -43,6 +43,18 @@ These serve the following roles:
 
       Example: <Network code=”IU” startDate=”2016-01-27T13:00:00” />
 
+   Note that for an example attribute, the <example> element should contain just
+   the textual value, not the key or quotes. So within the `code` attribute on
+   Network, the example would be just:
+
+   .. code-block:: XML
+
+    <xs:documentation><example>IU</example></xs:documentation>
+
+   which would produce::
+
+      code=”IU”
+
 * <warning> - This is used to wrap the text that follows it in an ReStructuredText admonition wrapper.
 
    It is used, for example, to present a caution that a particular element may be deprecated

--- a/docs/schema-keywords.rst
+++ b/docs/schema-keywords.rst
@@ -6,19 +6,20 @@ generated documentation and those reading the XSD schema specification
 directly.
 
 To allow additional granularity and clarity in the generated
-documentation, special embedded keywords are parsed from the content
+documentation, special embedded elements and attributes are parsed from the content
 of standard documentation tags of `XML Schema <https://en.wikipedia.org/wiki/XML_Schema_(W3C)>`_.
 
-The following keywords are recognized in the standard `<documentation>` tags:
+The following elements and attributes are recognized in the standard `<documentation>` tags:
 
-#. "Example:"
-#. "Warning:"
-#. "LevelChoice:"
-#. "ElementChoice:"
+#. <example>
+#. <warning>
+#. <levelDesc>
+#. LevelChoice
+#. ElementChoice
 
 These serve the following roles:
 
-* "Example:" - Text that follows appears after Example: in the documentation.
+* <example> - An XML element that contains an example of the relevant element in the StationXML documentation.
 
    For instance, NetworkType element contains 2 `documentation` tags:
 
@@ -26,33 +27,38 @@ These serve the following roles:
 
       <xs:complexType name="NetworkType">
          <xs:annotation>
-            <xs:documentation>The Network container. All station metadata for this network is contained within this element.
-               Description element may be included with the official network name and other descriptive information.
-               An Identifier element may be included to designate a persistent identifier (e.g. DOI) to use for citation.
-               A Comment element may be included for arbitrary comments.
-            </xs:documentation>
-            <xs:documentation>Example:&lt;Network code="IU" startDate=2016-01-27T13:00:00&gt;</xs:documentation>
+         <xs:documentation>The Network container. All station metadata for this network is contained within this element.
+     		A Description element may be included with the official network name and other descriptive information.
+     		An Identifier element may be included to designate a persistent identifier (e.g. DOI) to use for citation.
+     		A Comment element may be included for additional comments.
+        </xs:documentation>
+        <xs:documentation><example><Network code="IU" startDate="2016-01-27T13:00:00" /></example></xs:documentation>
          </xs:annotation>
       </xs:complexType>
 
    The first documentation text appears directly beneath the Network
    element in the StationXML documentation (it is the Network
    description), while the second is used to create the example
-   beneath the description:
+   beneath the description::
 
-   Example: <Network code=”IU” startDate=2016-01-27T13:00:00>
+      Example: <Network code=”IU” startDate=”2016-01-27T13:00:00” />
 
-* "Warning:" - This is used to wrap the text that follows it in an ReStructuredText admonition wrapper.
+* <warning> - This is used to wrap the text that follows it in an ReStructuredText admonition wrapper.
 
    It is used, for example, to present a caution that a particular element may be deprecated
    in future versions of the StationXML documentation.
 
-* "LevelChoice:X" - where X is in {N, S, C}.
+* <levelDesc> - An XML element that contains a description of the relevant element in the StationXML documentation at a given level.
+
+  This exists as a container to hold the description as text, along with a LevelChoice
+  attribute to specify the level.
+
+* LevelChoice="X" - where X is in {N, S, C}.
 
    When a particular XML element is used more than once in the documentation, this allows
    us to specify different documentation for different BaseNodeElements.
    For example, Network, Station and Channel types all inherit code from the BaseNodeElement.
-   By using the LevelChoice flag, we can specify a unique Description and Example for the
+   By using the LevelChoice attribute on a <levelDesc> or an <example> element, we can specify a unique Description and Example for the
    Network.code, Station.code and Channel.code.
 
    For example,
@@ -60,33 +66,35 @@ These serve the following roles:
    .. code-block:: XML
 
       <xs:attribute name="code" type="xs:string" use="required">
-         <xs:annotation>
-            <xs:documentation>LevelChoice:N Name of Network Example:code='IU'</xs:documentation>
-            <xs:documentation>LevelChoice:S Name of Station Example:code='ANMO'</xs:documentation>
-            <xs:documentation>LevelChoice:C Name of Channel Example:code='BHZ'</xs:documentation>
-         </xs:annotation>
+        <xs:annotation>
+          <xs:documentation><levelDesc LevelChoice="N">Name of Network</levelDesc></xs:documentation>
+          <xs:documentation><levelDesc LevelChoice="S">Name of Station</levelDesc></xs:documentation>
+          <xs:documentation><levelDesc LevelChoice="C">Name of Channel</levelDesc></xs:documentation>
+          <xs:documentation><example LevelChoice="N">IU</example></xs:documentation>
+          <xs:documentation><example LevelChoice="S">ANMO</example></xs:documentation>
+          <xs:documentation><example LevelChoice="C">BHZ</example></xs:documentation>
+        </xs:annotation>
       </xs:attribute>
 
    If LevelChoice is not used (or if no choice is present that matches
    the Network, Station or Channel element, then the default value is
    used.
 
-* "ElementChoice:" - Serves a similar function to LevelChoice except
+* ElementChoice="X" - Serves a similar function to LevelChoice except
   that it helps disambiguate StationXML elements that share a common
-  parent type.  For example:
+  parent type.  For example, the unit attribute within FloatType:
 
   .. code-block:: XML
 
-      <xs:complexType name="FloatType">
-        <xs:attribute name="unit" type="xs:string" use="optional">
-          <xs:annotation>
-            <xs:documentation>The unit of measurement. Use SI unit names and symbols whenever possible.
-            </xs:documentation>
-            <xs:documentation>Example:unit='SECONDS'</xs:documentation>
-            <xs:documentation>ElementChoice:WATERLEVEL Example:unit=&apos;METERS&apos;</xs:documentation>.
-            <xs:documentation>ElementChoice:AMPLITUDE Example:unit=&apos;METERS&apos;</xs:documentation>
-          </xs:annotation>
-      </xs:complexType>
+      <xs:attribute name="unit" type="xs:string" use="optional">
+        <xs:annotation>
+          <xs:documentation>The unit of measurement. Use *SI* unit names and symbols whenever possible
+            (e.g., 'm' instead of 'METERS').</xs:documentation>
+          <xs:documentation><example>SECONDS</example></xs:documentation>
+          <xs:documentation><example ElementChoice="WaterLevel">m</example></xs:documentation>
+          <xs:documentation><example ElementChoice="Amplitude">m</example></xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
 
    Because several elements are of FloatType but may have different
    units (METERS, SECONDS, etc), we use this to give more specific

--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -134,7 +134,7 @@
 								network, including inactive or terminated stations.
 							</xs:documentation>
               <xs:documentation><example><TotalNumberStations>24</TotalNumberStations></example></xs:documentation>
-              <xs:documentation>Warning:This field is likely to be deprecated in future versions of StationXML</xs:documentation>
+              <xs:documentation><warning>This field is likely to be deprecated in future versions of StationXML</warning></xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="SelectedNumberStations" type="fsx:CounterType" minOccurs="0">
@@ -143,7 +143,7 @@
 								in this document.
 							</xs:documentation>
               <xs:documentation><example><SelectedNumberStations>12</SelectedNumberStations></example></xs:documentation>
-              <xs:documentation>Warning:This field is likely to be deprecated in future versions of StationXML</xs:documentation>
+              <xs:documentation><warning>This field is likely to be deprecated in future versions of StationXML</warning></xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Station" type="fsx:StationType" minOccurs="0"
@@ -224,7 +224,7 @@
 					<xs:element name="CreationDate" type="xs:dateTime" minOccurs="0">
 						<xs:annotation>
               <xs:documentation>Date and time (UTC) when the station was first installed.</xs:documentation>
-              <xs:documentation>Warning:This field is likely to be deprecated in future versions of StationXML</xs:documentation>
+              <xs:documentation><warning>This field is likely to be deprecated in future versions of StationXML</warning></xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="TerminationDate" type="xs:dateTime" minOccurs="0">
@@ -232,19 +232,19 @@
 							<xs:documentation>Date and time (UTC) when the station was terminated or
 								will be terminated. Do not include this field if a termination date is not available or is not relevant.
 							</xs:documentation>
-              <xs:documentation>Warning:This field is likely to be deprecated in future versions of StationXML</xs:documentation>
+              <xs:documentation><warning>This field is likely to be deprecated in future versions of StationXML</warning></xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="TotalNumberChannels" type="fsx:CounterType" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>Total number of channels recorded at this station.</xs:documentation>
-							<xs:documentation>Warning:This field is likely to be deprecated in future versions of StationXML.</xs:documentation>
+							<xs:documentation><warning>This field is likely to be deprecated in future versions of StationXML.</warning></xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="SelectedNumberChannels" type="fsx:CounterType" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The number of channels selected in the request that resulted in this document.</xs:documentation>
-							<xs:documentation>Warning:This field is likely to be deprecated in future versions of StationXML.</xs:documentation>
+							<xs:documentation><warning>This field is likely to be deprecated in future versions of StationXML.</warning></xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="ExternalReference" type="fsx:ExternalReferenceType"

--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -105,7 +105,7 @@
 		<xs:attribute name="schemaVersion" type="xs:decimal" use="required">
 			<xs:annotation>
 				<xs:documentation>The StationXML schema version of this document.</xs:documentation>
-				<xs:documentation>Example:schemaVersion=&apos;1.1&apos;</xs:documentation>
+				<xs:documentation><example>1.1</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:anyAttribute namespace="##other" processContents="lax"/>
@@ -366,7 +366,7 @@
 											<xs:annotation>
 												<xs:documentation>The unit of drift value.
 												</xs:documentation>
-												<xs:documentation>Example:unit='SECONDS/SAMPLE'
+												<xs:documentation><example>SECONDS/SAMPLE</example>
 												</xs:documentation>
 											</xs:annotation>
 										</xs:attribute>
@@ -425,11 +425,11 @@
 	<xs:documentation>
 		The locationCode is typically used to group channels from a common sensor.
 		For example, the channels of the primary sensor at global IDA-IRIS
-		stations have locationCode = &apos;00&apos;: 00_BHZ, 00_BHE, 00_BHN, 00_LHZ, ..., etc.
+		stations have locationCode = \"00\": 00_BHZ, 00_BHE, 00_BHN, 00_LHZ, ..., etc.
     Even though it is required, locationCode may be, and often is, an empty string,
     however, it is recommended that the locationCode not be empty.
 	</xs:documentation>
-	<xs:documentation>Example:locationCode=&apos;30&apos;</xs:documentation>
+	<xs:documentation><example>30</example></xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 			</xs:extension>
@@ -703,7 +703,7 @@
 		<xs:attribute name="id" type="fsx:CounterType" use="optional">
 			<xs:annotation>
 				<xs:documentation>An ID for this comment</xs:documentation>
-				<xs:documentation>Example:id=12345</xs:documentation>
+				<xs:documentation><example>12345</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 
@@ -712,7 +712,7 @@
 				<xs:documentation>A subject for this comment.  Multiple comments with the same
 					subject should be considered related.
 				</xs:documentation>
-				<xs:documentation>Example:subject=&apos;Scheduled maintenance&apos;</xs:documentation>
+				<xs:documentation><example>Scheduled maintenance</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 	</xs:complexType>
@@ -985,13 +985,13 @@
 		<xs:attribute name="plusError" type="xs:double" use="optional">
 			<xs:annotation>
 				<xs:documentation>plus uncertainty or error in measured value.</xs:documentation>
-				<xs:documentation>Example:plusError=0.1</xs:documentation>
+				<xs:documentation><example>0.1</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="minusError" type="xs:double" use="optional">
 			<xs:annotation>
 				<xs:documentation>minus uncertainty or error in measured value.</xs:documentation>
-				<xs:documentation>Example:minusError=0.1</xs:documentation>
+				<xs:documentation><example>0.1</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="measurementMethod" type="xs:string" use="optional"/>
@@ -1018,9 +1018,9 @@
 				  <xs:annotation>
             <xs:documentation>The unit of measurement. Use *SI* unit names and symbols whenever possible
               (e.g., 'm' instead of 'METERS').</xs:documentation>
-            <xs:documentation>Example:unit='SECONDS'</xs:documentation>
-            <xs:documentation>ElementChoice:WATERLEVEL Example:unit=&apos;m&apos;</xs:documentation>
-            <xs:documentation>ElementChoice:AMPLITUDE Example:unit=&apos;m&apos;</xs:documentation>
+            <xs:documentation><example>SECONDS</example></xs:documentation>
+            <xs:documentation><example ElementChoice="WATERLEVEL">m</example></xs:documentation>
+            <xs:documentation><example ElementChoice="AMPLITUDE">m</example></xs:documentation>
 				  </xs:annotation>
 				</xs:attribute>
 				<xs:attributeGroup ref="fsx:uncertaintyDouble"/>
@@ -1038,7 +1038,7 @@
 						<xs:annotation>
 							<xs:documentation>The type of unit being used.
 							</xs:documentation>
-							<xs:documentation>Example:unit='SECONDS'
+							<xs:documentation><example>SECONDS</example>
 							</xs:documentation>
 						</xs:annotation>
 					</xs:attribute>
@@ -1053,7 +1053,7 @@
 						<xs:annotation>
 							<xs:documentation>The type of unit being used.
 							</xs:documentation>
-							<xs:documentation>Example:unit='VOLTS'
+							<xs:documentation><example>VOLTS</example>
 							</xs:documentation>
 						</xs:annotation>
 					</xs:attribute>
@@ -1070,7 +1070,7 @@
 					<xs:annotation>
 						<xs:documentation>The type of unit being used.
 						</xs:documentation>
-						<xs:documentation>Example:unit='DEGREES'
+						<xs:documentation><example>DEGREES</example>
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
@@ -1090,7 +1090,7 @@
 					<xs:annotation>
 						<xs:documentation>The type of unit being used.
 						</xs:documentation>
-						<xs:documentation>Example:unit='DEGREES'
+						<xs:documentation><example>DEGREES</example>
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
@@ -1121,7 +1121,7 @@
 					<xs:annotation>
 						<xs:documentation>The type of unit being used.
 						</xs:documentation>
-						<xs:documentation>Example:unit='DEGREES'
+						<xs:documentation><example>DEGREES</example>
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
@@ -1153,7 +1153,7 @@
 					<xs:annotation>
 						<xs:documentation>The type of unit being used.
 						</xs:documentation>
-						<xs:documentation>Example:unit='DEGREES'
+						<xs:documentation><example>DEGREES</example>
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
@@ -1174,7 +1174,7 @@
 						<xs:annotation>
 							<xs:documentation>The type of unit being used.
 							</xs:documentation>
-							<xs:documentation>Example:unit='DEGREES'
+							<xs:documentation><example>DEGREES</example>
 							</xs:documentation>
 						</xs:annotation>
 				</xs:attribute>
@@ -1193,7 +1193,7 @@
 					<xs:annotation>
 						<xs:documentation>The type of unit being used.
 						</xs:documentation>
-						<xs:documentation>Example:unit='m'
+						<xs:documentation><example>m</example>
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
@@ -1208,7 +1208,7 @@
 					<xs:annotation>
 						<xs:documentation>The type of unit being used.
 						</xs:documentation>
-						<xs:documentation>Example:unit='HERTZ'
+						<xs:documentation><example>HERTZ</example>
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
@@ -1260,7 +1260,7 @@
 					<xs:annotation>
 						<xs:documentation>The type of unit being used.
 						</xs:documentation>
-						<xs:documentation>Example:unit='SAMPLES/S'
+						<xs:documentation><example>SAMPLES/S</example>
 						</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
@@ -1514,7 +1514,7 @@
 				<xs:attribute name="type" type="xs:string">
 					<xs:annotation>
 						<xs:documentation>Identifier type</xs:documentation>
-						<xs:documentation>Example:type="DOI"</xs:documentation>
+						<xs:documentation><example>DOI</example></xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 			</xs:extension>
@@ -1660,10 +1660,12 @@
 		</xs:sequence>
 		<xs:attribute name="code" type="xs:string" use="required">
 			<xs:annotation>
-        <xs:documentation>Example:code='IU' or code='ANMO'</xs:documentation>
-        <xs:documentation>LevelChoice:N Name of Network Example:code='IU'</xs:documentation>
-        <xs:documentation>LevelChoice:S Name of Station Example:code='ANMO'</xs:documentation>
-        <xs:documentation>LevelChoice:C Name of Channel Example:code='BHZ'</xs:documentation>
+        <xs:documentation>LevelChoice:N Name of Network</xs:documentation>
+        <xs:documentation>LevelChoice:S Name of Station</xs:documentation>
+        <xs:documentation>LevelChoice:C Name of Channel</xs:documentation>
+        <xs:documentation><example LevelChoice="N">IU</example></xs:documentation>
+        <xs:documentation><example LevelChoice="S">ANMO</example></xs:documentation>
+        <xs:documentation><example LevelChoice="C">BHZ</example></xs:documentation>
       </xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="startDate" type="xs:dateTime">
@@ -1672,7 +1674,7 @@
         <xs:documentation>LevelChoice:N Start date of network</xs:documentation>
         <xs:documentation>LevelChoice:S Start date of station epoch</xs:documentation>
         <xs:documentation>LevelChoice:C Start date of channel epoch</xs:documentation>
-        <xs:documentation>Example:startDate=2016-07-01T00:00:00</xs:documentation>
+        <xs:documentation><example>2016-07-01T00:00:00</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="endDate" type="xs:dateTime">
@@ -1681,29 +1683,28 @@
         <xs:documentation>LevelChoice:N End date of network</xs:documentation>
         <xs:documentation>LevelChoice:S End date of station epoch</xs:documentation>
         <xs:documentation>LevelChoice:C End date of channel epoch</xs:documentation>
-        <xs:documentation>Example:endDate=2018-01-27T00:00:00</xs:documentation>
+        <xs:documentation><example>2018-01-27T00:00:00</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="sourceID" type="xs:anyURI">
 			<xs:annotation>
 				<xs:documentation>A data source identifier in URI form</xs:documentation>
-				<xs:documentation>Example:sourceID=&apos;http://some/path&apos;</xs:documentation>
+				<xs:documentation><example>http://some/path</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="restrictedStatus" type="fsx:RestrictedStatusType" use="optional">
 			<xs:annotation>
-				<xs:documentation>One of:&apos;open&apos;, &apos;closed&apos;, &apos;partial&apos;</xs:documentation>
-				<xs:documentation>Example:restrictedStatus=&apos;open&apos;</xs:documentation>
+				<xs:documentation>One of: \"open\", \"closed\", \"partial\"</xs:documentation>
+				<xs:documentation><example>open</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="alternateCode" type="xs:string" use="optional">
 			<xs:annotation>
         <xs:documentation>A code use for display or association</xs:documentation>
         <xs:documentation>
-          LevelDefault: A code use for display or association
-          LevelChoice:N Example:alternateCode='GSN'
-          LevelChoice:S Example:alternateCode='ALQ'
-          LevelChoice:C Example:alternateCode='Z'
+          <example LevelChoice="N">GSN</example>
+          <example LevelChoice="S">ALQ</example>
+          <example LevelChoice="C">Z</example>
         </xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
@@ -1711,10 +1712,9 @@
 			<xs:annotation>
         <xs:documentation>LevelDefault:A previously used code if different from the current code</xs:documentation>
         <xs:documentation>
-          LevelDefault: A previously used code if different from the current code
-          LevelChoice:N Example:historicalCode='II'
-          LevelChoice:S Example:historicalCode='albq'
-          LevelChoice:C Example:historicalCode='bhz'
+          <example LevelChoice="N">II</example>
+          <example LevelChoice="S">albq</example>
+          <example LevelChoice="C">bhz</example>
         </xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
@@ -1730,13 +1730,13 @@
 		<xs:attribute name="start" type="xs:dateTime" use="required">
 			<xs:annotation>
 				<xs:documentation>start date of extent</xs:documentation>
-				<xs:documentation>Example:start=1988-01-01T00:00:00</xs:documentation>
+				<xs:documentation><example>1988-01-01T00:00:00</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="end" type="xs:dateTime" use="required">
 			<xs:annotation>
 				<xs:documentation>end date of extent</xs:documentation>
-				<xs:documentation>Example:end=1988-12-31T00:00:00</xs:documentation>
+				<xs:documentation><example>1988-12-31T00:00:00</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:anyAttribute namespace="##other" processContents="lax"/>
@@ -1753,13 +1753,13 @@
 		<xs:attribute name="start" type="xs:dateTime" use="required">
 			<xs:annotation>
 				<xs:documentation>start date of span</xs:documentation>
-				<xs:documentation>Example:start=1988-01-01T00:00:00</xs:documentation>
+				<xs:documentation><example>1988-01-01T00:00:00</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="end" type="xs:dateTime" use="required">
 			<xs:annotation>
 				<xs:documentation>end date of span</xs:documentation>
-				<xs:documentation>Example:end=1988-12-31T00:00:00</xs:documentation>
+				<xs:documentation><example>1988-12-31T00:00:00</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="numberSegments" type="xs:integer" use="required">
@@ -1768,7 +1768,7 @@
 					specified time range. A value of 1 indicates that the time series is continuous
 					from start to end.
 				</xs:documentation>
-			  <xs:documentation>Example:numberSegments=2</xs:documentation>
+			  <xs:documentation><example>2</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="maximumTimeTear" type="xs:decimal" use="optional">
@@ -1776,7 +1776,7 @@
 				<xs:documentation> The maximum time tear (gap or overlap) in seconds between time
 					series segments in the specified range.
 				</xs:documentation>
-				<xs:documentation>Example:maximumTimeTear=0.01</xs:documentation>
+				<xs:documentation><example>0.01</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:anyAttribute namespace="##other" processContents="lax"/>

--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -675,9 +675,11 @@
 			<xs:element name="Value" type="xs:string">
 				<xs:annotation>
 					<xs:documentation>Comment text.</xs:documentation>
-          <xs:documentation>LevelChoice:N Example:&lt;Value&gt;Temporary network deployment&lt;/Value&gt;</xs:documentation>
-          <xs:documentation>LevelChoice:S Example:&lt;Value&gt;GPS CLock is unlocked&lt;/Value&gt;</xs:documentation>
-          <xs:documentation>LevelChoice:C Example:&lt;Value&gt;Large number of spikes&lt;/Value&gt;</xs:documentation>
+					<xs:documentation>
+	          <example  LevelChoice="N"><Value>Temporary network deployment</Value></example>
+	          <example  LevelChoice="S"><Value>GPS CLock is unlocked</Value></example>
+	          <example  LevelChoice="C"><Value>Large number of spikes</Value></example>
+					</xs:documentation>
 			  </xs:annotation>
       			</xs:element>
 			<xs:element name="BeginEffectiveTime" type="xs:dateTime" minOccurs="0">

--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -1019,8 +1019,8 @@
             <xs:documentation>The unit of measurement. Use *SI* unit names and symbols whenever possible
               (e.g., 'm' instead of 'METERS').</xs:documentation>
             <xs:documentation><example>SECONDS</example></xs:documentation>
-            <xs:documentation><example ElementChoice="WATERLEVEL">m</example></xs:documentation>
-            <xs:documentation><example ElementChoice="AMPLITUDE">m</example></xs:documentation>
+            <xs:documentation><example ElementChoice="WaterLevel">m</example></xs:documentation>
+            <xs:documentation><example ElementChoice="Amplitude">m</example></xs:documentation>
 				  </xs:annotation>
 				</xs:attribute>
 				<xs:attributeGroup ref="fsx:uncertaintyDouble"/>

--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -83,7 +83,7 @@
 				<xs:annotation>
 					<xs:documentation>Name of the software module that generated this document.
 					</xs:documentation>
-					<xs:documentation>Example:&lt;Module&gt;SeisComp3&lt;/Module&gt;</xs:documentation>
+					<xs:documentation><example><Module>SeisComp3</Module></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="ModuleURI" type="xs:anyURI" minOccurs="0">
@@ -117,7 +117,7 @@
 		An Identifier element may be included to designate a persistent identifier (e.g. DOI) to use for citation.
 		A Comment element may be included for additional comments.
       		</xs:documentation>
-      		<xs:documentation>Example:&lt;Network code="IU" startDate=2016-01-27T13:00:00&gt;</xs:documentation>
+      		<xs:documentation><example><Network code="IU" startDate="2016-01-27T13:00:00" /></example></xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
 			<xs:extension base="fsx:BaseNodeType">
@@ -133,7 +133,7 @@
 							<xs:documentation>The total number of stations in this
 								network, including inactive or terminated stations.
 							</xs:documentation>
-              <xs:documentation>Example:&lt;TotalNumberStations&gt;24&lt;/TotalNumberStations&gt;</xs:documentation>
+              <xs:documentation><example><TotalNumberStations>24</TotalNumberStations></example></xs:documentation>
               <xs:documentation>Warning:This field is likely to be deprecated in future versions of StationXML</xs:documentation>
 						</xs:annotation>
 					</xs:element>
@@ -142,7 +142,7 @@
 							<xs:documentation>The number of stations selected in the request that resulted
 								in this document.
 							</xs:documentation>
-              <xs:documentation>Example:&lt;SelectedNumberStations&gt;12&lt;/SelectedNumberStations&gt;</xs:documentation>
+              <xs:documentation><example><SelectedNumberStations>12</SelectedNumberStations></example></xs:documentation>
               <xs:documentation>Warning:This field is likely to be deprecated in future versions of StationXML</xs:documentation>
 						</xs:annotation>
 					</xs:element>
@@ -166,19 +166,19 @@
 					<xs:element name="Latitude" type="fsx:LatitudeType">
 						<xs:annotation>
 		<xs:documentation>Station latitude, by default in degrees. Where the bulk of the equipment is located (or another appropriate site location).</xs:documentation>
-		<xs:documentation>Example:&lt;Latitude unit=&quot;DEGREES&quot; datum=&quot;WGS84&quot;&gt;34.9459&lt;/Latitude&gt;</xs:documentation>
+		<xs:documentation><example><Latitude unit="DEGREES" datum="WGS84">34.9459</Latitude></example></xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Longitude" type="fsx:LongitudeType">
 						<xs:annotation>
 		<xs:documentation>Station longitude, by default in degrees. Where the bulk of the equipment is located (or another appropriate site location).</xs:documentation>
-		<xs:documentation>Example:&lt;Longitude unit=&quot;DEGREES&quot; datum=&quot;WGS84&quot;&gt;-106.4572&lt;/Longitude&gt;</xs:documentation>
+		<xs:documentation><example><Longitude unit="DEGREES" datum="WGS84">-106.4572</Longitude></example></xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Elevation" type="fsx:DistanceType">
 						<xs:annotation>
 							<xs:documentation>Elevation of local ground surface level at station, by default in meters.</xs:documentation>
-							<xs:documentation>Example:&lt;Elevation unit=&quot;m&quot;&gt;1850.0&lt;/Elevation&gt;</xs:documentation>
+							<xs:documentation><example><Elevation unit="m">1850.0</Elevation></example></xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Site" type="fsx:SiteType">
@@ -193,7 +193,7 @@
 		<xs:documentation>Elevation of the water surface (in meters) for underwater sites, where 0 is mean sea level.
 		If you put an ocean-bottom seismometer (OBS) on a lake bottom, where the lake surface is at elevation=0, then you should set WaterLevel=0.
 		</xs:documentation>
-		<xs:documentation>Example:&lt;WaterLevel&gt;1200&lt;/WaterLevel&gt;</xs:documentation>
+		<xs:documentation><example><WaterLevel>1200</WaterLevel></example></xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Vault" type="xs:string" minOccurs="0">
@@ -283,7 +283,7 @@
 								Often the same as the station latitude, but
 								when different the channel latitude is the true location of the sensor.
 							</xs:documentation>
-							<xs:documentation>Example:&lt;Latitude unit=&quot;DEGREES&quot; datum=&quot;WGS84&quot;&gt;34.9459&lt;/Latitude&gt;</xs:documentation>
+							<xs:documentation><example><Latitude unit="DEGREES" datum="WGS84">34.9459</Latitude></example></xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Longitude" type="fsx:LongitudeType">
@@ -292,7 +292,7 @@
 								Often the same as the station longitude, but
 								when different the channel longitude is the true location of the sensor.
 							</xs:documentation>
-							<xs:documentation>Example:&lt;Longitude unit=&quot;DEGREES&quot; datum=&quot;WGS84&quot;&gt;-106.4572&lt;/Longitude&gt;</xs:documentation>
+							<xs:documentation><example><Longitude unit="DEGREES" datum="WGS84">-106.4572</Longitude></example></xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Elevation" type="fsx:DistanceType">
@@ -332,7 +332,7 @@
                 The value between the &lt;Type&gt; tags must be one of:
 								TRIGGERED, CONTINUOUS, HEALTH, GEOPHYSICAL, WEATHER, FLAG or SYNTHESIZED.
 							</xs:documentation>
-              <xs:documentation>Example:&lt;Type&gt;CONTINUOUS&lt;/Type&gt;</xs:documentation>
+              <xs:documentation><example><Type>CONTINUOUS</Type></example></xs:documentation>
 
 						</xs:annotation>
 						<xs:simpleType>
@@ -378,9 +378,14 @@
 						<xs:annotation>
 							<xs:documentation>Units of calibration (e.g., V (for Volts) or A (for amps))</xs:documentation>
 							<xs:documentation>Use *SI* units when possible</xs:documentation>
-              <xs:documentation>Example: &lt;CalibrationUnits&gt;&lt;Name&gt;V&lt;/Name&gt;
-                                &lt;Description&gt;Volts&lt;/Description&gt;
-                                &lt;/CalibrationUnits&gt;</xs:documentation>
+              <xs:documentation>
+								<example>
+<CalibrationUnits>
+  <Name>V</Name>
+  <Description>Volts</Description>
+</CalibrationUnits>
+								</example>
+							</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Sensor" type="fsx:EquipmentType" minOccurs="0">
@@ -678,13 +683,13 @@
 			<xs:element name="BeginEffectiveTime" type="xs:dateTime" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Start time for when comment applies.</xs:documentation>
-					<xs:documentation>Example:&lt;BeginEffectiveTime&gt;2008-09-15T00:00:00&lt;/BeginEffectiveTime&gt;</xs:documentation>
+					<xs:documentation><example><BeginEffectiveTime>2008-09-15T00:00:00</BeginEffectiveTime></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="EndEffectiveTime" type="xs:dateTime" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>End time for when comment applies.</xs:documentation>
- 					<xs:documentation>Example:&lt;EndEffectiveTime&gt;2008-09-16T12:00:00&lt;/EndEffectiveTime&gt;</xs:documentation>
+ 					<xs:documentation><example><EndEffectiveTime>2008-09-16T12:00:00</EndEffectiveTime></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Author" type="fsx:PersonType" minOccurs="0" maxOccurs="unbounded">
@@ -723,7 +728,7 @@
                 For a digial z-transform (e.g., for an IIR filter), this should be
                 "DIGITAL (Z-TRANSFORM)"
 							</xs:documentation>
-              <xs:documentation>Example: &lt;PzTransferFunctionType&gt;LAPLACE (RADIANS/SECOND)&lt;/PzTransferFunctionType&gt;"
+              <xs:documentation><example><PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType></example>
 							</xs:documentation>
 						</xs:annotation>
 						<xs:simpleType>
@@ -1223,7 +1228,7 @@
             Sample rate in samples per second.
             SampleRate is optional unless SampleRateRatio is present, in which case
             SampleRate is required.
-            Example:&lt;SampleRate units='SAMPLES/S'&gt;40.0&lt;/SampleRate&gt;
+            <example><SampleRate units='SAMPLES/S'>40.0</SampleRate></example>
           </xs:documentation>
 		    </xs:annotation>
       </xs:element>
@@ -1234,10 +1239,13 @@
             If present, then &lt;SampleRate&gt; must also be present.
             It can be useful for very slow data (e.g., greater than 10 days),
             since it allows for greater precision in the stored value.
-            Example:&lt;SampleRate&gt;3.859999367e-07&lt;/SampleRate&gt;
-            &lt;SampleRateRatio&gt;&lt;NumberSamples&gt;1&lt;/NumberSamples&gt;
-            &lt;NumberSeconds&gt;2590674&lt;/NumberSeconds&gt;
-            &lt;/SampleRateRatio&gt;
+            <example>
+<SampleRate>3.859999367e-07</SampleRate>
+<SampleRateRatio>
+	<NumberSamples>1</NumberSamples>
+	<NumberSeconds>2590674</NumberSeconds>
+</SampleRateRatio>
+						</example>
           </xs:documentation>
 		    </xs:annotation>
 		  </xs:element>
@@ -1291,7 +1299,7 @@
 		<xs:attribute name="number" type="xs:integer">
 				<xs:annotation>
 					<xs:documentation>The position index of the pole (or zero) in the array of poles[] (or zeros[])</xs:documentation>
-          <xs:documentation>Example:&lt;Pole number=&apos;1&apos;&gt;</xs:documentation>
+          <xs:documentation><example><Pole number="1" /></example></xs:documentation>
 				</xs:annotation>
 		</xs:attribute>
 	</xs:complexType>
@@ -1316,14 +1324,14 @@
 			<xs:element name="Agency" type="xs:string">
 				<xs:annotation>
 			    		<xs:documentation>An operating agency and associated contact persons.</xs:documentation>
-					<xs:documentation>Example:&lt;Agency&gt;USGS&lt;/Agency&gt;</xs:documentation>
+					<xs:documentation><example><Agency>USGS</Agency></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Contact" type="fsx:PersonType" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="WebSite" type="xs:anyURI" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Website of operating agency</xs:documentation>
-					<xs:documentation>Example:&lt;WebSite&gt;http://usgs.gov&lt;/WebSite&gt;</xs:documentation>
+					<xs:documentation><example><WebSite>http://usgs.gov</WebSite></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -1338,19 +1346,19 @@
 			<xs:element name="Name" type="xs:string" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>Name of contact or author</xs:documentation>
-					<xs:documentation>Example:&lt;Name&gt;Alfred E. Neuman&lt;/Name&gt;</xs:documentation>
+					<xs:documentation><example><Name>Alfred E. Neuman</Name></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Agency" type="xs:string" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>Agency of contact or author</xs:documentation>
-					<xs:documentation>Example:&lt;Agency&gt;Mad Magazine, Inc.&lt;/Agency&gt;</xs:documentation>
+					<xs:documentation><example><Agency>Mad Magazine, Inc.</Agency></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Email" type="fsx:EmailType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>Email of contact or author</xs:documentation>
-					<xs:documentation>Example:&lt;Email&gt;a.neuman@nosuchsite.com&lt;/Email&gt;</xs:documentation>
+					<xs:documentation><example><Email>a.neuman@nosuchsite.com</Email></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Phone" type="fsx:PhoneNumberType" minOccurs="0" maxOccurs="unbounded">
@@ -1369,38 +1377,38 @@
 			<xs:element name="Name" type="xs:string">
 				<xs:annotation>
 					<xs:documentation>Name of the site</xs:documentation>
-					<xs:documentation>Example:&lt;Name&gt;Albuquerque, New Mexico&lt;/Name&gt;</xs:documentation>
+					<xs:documentation><example><Name>Albuquerque, New Mexico</Name></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Description" type="xs:string" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>A longer description of the location of this station</xs:documentation>
-					<xs:documentation>Example:&lt;Description&gt;NW corner of Yellowstone National Park&lt;/Description&gt;</xs:documentation>
+					<xs:documentation><example><Description>NW corner of Yellowstone National Park</Description></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Town" type="xs:string" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>The town or city closest to the station.</xs:documentation>
-					<xs:documentation>Example:&lt;Town&gt;Albuquerque&lt;/Town&gt;</xs:documentation>
+					<xs:documentation><example><Town>Albuquerque</Town></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="County" type="xs:string" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>The county where the station is located</xs:documentation>
-					<xs:documentation>Example:&lt;County&gt;Bernalillo&lt;/County&gt;</xs:documentation>
+					<xs:documentation><example><County>Bernalillo</County></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 
 			<xs:element name="Region" type="xs:string" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>The state, province, or region of this site.</xs:documentation>
-					<xs:documentation>Example:&lt;Region&gt;Southwest U.S.&lt;/Region&gt;</xs:documentation>
+					<xs:documentation><example><Region>Southwest U.S.</Region></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Country" type="xs:string" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>The country of this site.</xs:documentation>
-					<xs:documentation>Example:&lt;Country&gt;U.S.A.&lt;/Country&gt;</xs:documentation>
+					<xs:documentation><example><Country>U.S.A.</Country></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
@@ -1443,19 +1451,19 @@
 			<xs:element name="CountryCode" type="xs:integer" minOccurs="0">
 				<xs:annotation>
  					<xs:documentation>Telephone country code</xs:documentation>
-					<xs:documentation>Example:&lt;CountryCode&gt;64&lt;/CountryCode&gt;</xs:documentation>
+					<xs:documentation><example><CountryCode>64</CountryCode></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="AreaCode" type="xs:integer">
 				<xs:annotation>
 					<xs:documentation>Telephone area code</xs:documentation>
-					<xs:documentation>Example:&lt;AreaCode&gt;408&lt;/CountryCode&gt;</xs:documentation>
+					<xs:documentation><example><AreaCode>408</AreaCode></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="PhoneNumber">
 				<xs:annotation>
 					<xs:documentation>Telephone number</xs:documentation>
-					<xs:documentation>Example:&lt;PhoneNumber&gt;5551212&lt;/PhoneNumber&gt;</xs:documentation>
+					<xs:documentation><example><PhoneNumber>5551212</PhoneNumber></example></xs:documentation>
 				</xs:annotation>
 				<xs:simpleType>
 					<xs:restriction base="xs:string">
@@ -1504,7 +1512,7 @@
 				<xs:attribute name="type" type="xs:string">
 					<xs:annotation>
 						<xs:documentation>Identifier type</xs:documentation>
-						<xs:documentation>Example:type=&apos;DOI&apos;</xs:documentation>
+						<xs:documentation>Example:type="DOI"</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
 			</xs:extension>
@@ -1629,7 +1637,7 @@
           <xs:documentation>LevelChoice:N Description of the Network</xs:documentation>
           <xs:documentation>LevelChoice:S Description of the Station</xs:documentation>
           <xs:documentation>LevelChoice:C Description of the Channel</xs:documentation>
-					<xs:documentation>Example:&lt;Description&gt;This is a description&lt;/Description&gt;</xs:documentation>
+					<xs:documentation><example><Description>This is a description</Description></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Identifier" type="fsx:IdentifierType" minOccurs="0" maxOccurs="unbounded"/>

--- a/fdsn-station.xsd
+++ b/fdsn-station.xsd
@@ -33,22 +33,25 @@
         in this this schema document.
 
         To allow additional granularity and clarity in the generated documentation, special embedded
-        keywords are parsed from the content (value) of the <documentation> tags.  These embedded
-        keywords are as follows:
+        elements and attributes are parsed from the content of the <documentation> tags.  These embedded
+        items are as follows:
 
-        1. "Example:" - Text that follows appears after Example for the relevent element
-           in the StationXML documentation.
+        1. <example> - An XML element that contains an example of the relevent element
+           in the StationXML documentation. May have a LevelChoice attribute.
 
-        2. "Warning:" - Text that follows appears included in an admonition wrapper.
+        2. <warning> - Text appears included in an admonition wrapper.
            It is typically used to indicate features that may be deprecated in the future.
 
-        3. "LevelChoice:X" - Where X is one of "N" (network), "S" (station) or "C" (channel).
-           This is used so that documentation can be specific to level X for shared XML elements.
+        3. <levelDesc> - An XML element that contains a description of the relevant element
+            in the StationXML documentation at a given level. Must have a  LevelChoice attribute.
 
-        4. "ElementChoice:TAG_NAME" - Similar to LevelChoice, but allows elements built off a
+        4. LevelChoice="X" - Where X is one of "N" (network), "S" (station) or "C" (channel).
+           This attribute is used so that documentation can be specific to level X for shared XML elements.
+
+        5. ElementChoice="TAG_NAME" - Similar to LevelChoice, but allows elements built off a
            common basetype to have specific documentation.
-           For example: <xs:documentation>ElementChoice:WATERLEVEL Example:...  </xs:documentation>
-           The text after example will only be used for the WATERLEVEL element.
+           For example: <xs:documentation><example ElementChoice="WaterLevel">m</example></xs:documentation>
+           The text in the example will only be used for the WaterLevel element.
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:fsx="http://www.fdsn.org/xml/station/1"
 	targetNamespace="http://www.fdsn.org/xml/station/1" elementFormDefault="qualified"
@@ -1636,9 +1639,9 @@
 			<xs:element name="Description" type="xs:string" minOccurs="0">
 				<xs:annotation>
           <xs:documentation>Description of the Network, Station, or Channel</xs:documentation>
-          <xs:documentation>LevelChoice:N Description of the Network</xs:documentation>
-          <xs:documentation>LevelChoice:S Description of the Station</xs:documentation>
-          <xs:documentation>LevelChoice:C Description of the Channel</xs:documentation>
+          <xs:documentation><levelDesc LevelChoice="N">Description of the Network</levelDesc></xs:documentation>
+          <xs:documentation><levelDesc LevelChoice="S">Description of the Station</levelDesc></xs:documentation>
+          <xs:documentation><levelDesc LevelChoice="C">Description of the Channel</levelDesc></xs:documentation>
 					<xs:documentation><example><Description>This is a description</Description></example></xs:documentation>
 				</xs:annotation>
 			</xs:element>
@@ -1660,9 +1663,9 @@
 		</xs:sequence>
 		<xs:attribute name="code" type="xs:string" use="required">
 			<xs:annotation>
-        <xs:documentation>LevelChoice:N Name of Network</xs:documentation>
-        <xs:documentation>LevelChoice:S Name of Station</xs:documentation>
-        <xs:documentation>LevelChoice:C Name of Channel</xs:documentation>
+        <xs:documentation><levelDesc LevelChoice="N">Name of Network</levelDesc></xs:documentation>
+        <xs:documentation><levelDesc LevelChoice="S">Name of Station</levelDesc></xs:documentation>
+        <xs:documentation><levelDesc LevelChoice="C">Name of Channel</levelDesc></xs:documentation>
         <xs:documentation><example LevelChoice="N">IU</example></xs:documentation>
         <xs:documentation><example LevelChoice="S">ANMO</example></xs:documentation>
         <xs:documentation><example LevelChoice="C">BHZ</example></xs:documentation>
@@ -1671,18 +1674,18 @@
 		<xs:attribute name="startDate" type="xs:dateTime">
 			<xs:annotation>
 				<xs:documentation>Start date of network/station/channel epoch </xs:documentation>
-        <xs:documentation>LevelChoice:N Start date of network</xs:documentation>
-        <xs:documentation>LevelChoice:S Start date of station epoch</xs:documentation>
-        <xs:documentation>LevelChoice:C Start date of channel epoch</xs:documentation>
+        <xs:documentation><levelDesc LevelChoice="N">Start date of network</levelDesc></xs:documentation>
+        <xs:documentation><levelDesc LevelChoice="S">Start date of station epoch</levelDesc></xs:documentation>
+        <xs:documentation><levelDesc LevelChoice="C">Start date of channel epoch</levelDesc></xs:documentation>
         <xs:documentation><example>2016-07-01T00:00:00</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
 		<xs:attribute name="endDate" type="xs:dateTime">
 			<xs:annotation>
         <xs:documentation>End date of network/station/channel epoch</xs:documentation>
-        <xs:documentation>LevelChoice:N End date of network</xs:documentation>
-        <xs:documentation>LevelChoice:S End date of station epoch</xs:documentation>
-        <xs:documentation>LevelChoice:C End date of channel epoch</xs:documentation>
+        <xs:documentation><levelDesc LevelChoice="N">End date of network</levelDesc></xs:documentation>
+        <xs:documentation><levelDesc LevelChoice="S">End date of station epoch</levelDesc></xs:documentation>
+        <xs:documentation><levelDesc LevelChoice="C">End date of channel epoch</levelDesc></xs:documentation>
         <xs:documentation><example>2018-01-27T00:00:00</example></xs:documentation>
 			</xs:annotation>
 		</xs:attribute>


### PR DESCRIPTION
fix for #58 

Examples and LevelChoice now handled by subelements within annotation documentation elements. This makes sure examples are at least well-formed and allows potential to extract examples and validate them.

In order to get this to function, various html escapes were removed, for quotes, greater than and less than. These are handled by sphinx, so no need to escape in the xml. See also #36 and #37  